### PR TITLE
fix: catch-all push guard for chained commands (hook bypass bug)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -qE 'git push'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"master\" ]; then echo 'BLOCKED: Do not push directly to main/master. Use a PR.' >&2; exit 2; fi; merged=$(gh pr list --state merged --head \"$branch\" --json number --jq 'length' 2>/dev/null); if [ -z \"$merged\" ]; then echo \"BLOCKED: Could not check merged PR status for '$branch'. Verify gh auth and try again.\" >&2; exit 2; fi; if [ \"$merged\" -gt 0 ]; then echo \"BLOCKED: Branch '$branch' already has a merged PR. Create a new branch.\" >&2; exit 2; fi; fi",
+            "description": "Catch-all push guard — catches git push in chained commands (&&) that bypass the Bash(git push:*) matcher"
+          },
+          {
+            "type": "command",
             "command": "if echo \"$TOOL_INPUT\" | grep -qE 'git commit'; then if [ -f pyproject.toml ] || [ -f setup.py ]; then ruff check . 2>&1; if [ $? -ne 0 ]; then echo 'BLOCKED: Linter failed. Fix lint errors before committing.' >&2; exit 2; fi; fi; fi",
             "description": "Linter gate — run ruff before any git commit, block if it fails"
           },


### PR DESCRIPTION
## Problem

The `Bash(git push:*)` hook matcher only fires when the Bash command **starts** with `git push`. When commands are chained:

```bash
git add file && git commit -m "msg" && git push
```

The matcher sees `git add` as the command start and never fires. This bypasses the merged-PR check entirely — which is how Shannon pushed to `docs/roadmap` after PR #45 was already merged.

## Fix

Added a new hook in the generic `Bash` matcher that greps `$TOOL_INPUT` for `git push` anywhere in the command string. Runs the same three checks:
1. Block push to main/master
2. Block push to branches with merged PRs
3. Fail closed if `gh` can't verify

This is belt-and-suspenders — the specific `Bash(git push:*)` matcher still handles direct push commands, and this catch-all handles chained commands.

## Test plan
- [ ] `git push` alone → blocked on merged branch ✓ (existing matcher)
- [ ] `git add && git commit && git push` → blocked on merged branch ✓ (new catch-all)
- [ ] `git push` on fresh branch → allowed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)