### PR TITLE
chore: add .claude/settings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ node_modules/
 *.swp
 *.swo
 
+# Claude Code
+.claude/settings.json
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` to `.gitignore` — it's per-user Claude Code config, not project code
- Closes the gap that led to PR #47 (now closed)

## Test plan
- [x] Verify `.claude/settings.json` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)