### PR TITLE
feat: GitHub Actions CI — lint + test on every push (issue #44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    name: Lint + Test (Python 3.11)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Test (pytest)
+        run: pytest --tb=short
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — runs on every push to any branch, and on PRs to main
- `ruff check` lints the backend
- `pytest` runs the test suite (30 tests from M1)
- Python 3.11, pip cache keyed on `backend/pyproject.toml` for fast runs
- `GEMINI_API_KEY` injected from GitHub Actions secrets (tests that need Gemini won't fail CI if secret is set)

## Test plan

- [x] Workflow YAML syntax valid
- [ ] Add `GEMINI_API_KEY` to GitHub repo secrets (Settings → Secrets → Actions)
- [ ] Verify green on this PR after merge of feat/mvp-pipeline code (backend/ exists on main)

## Note

CI will only run successfully once `feat/mvp-pipeline` (PR #15, already merged) code is on main — `backend/` directory needs to exist. This PR can be merged now; the workflow will activate once `backend/` lands.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)