### PR TITLE
feat: add Terraform bootstrap job for S3 state bucket

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,6 +18,7 @@ on:
         default: "plan"
         type: choice
         options:
+          - bootstrap
           - plan
           - apply
 
@@ -51,11 +52,43 @@ jobs:
   # ── Plan (needs AWS creds) ───────────────────────────────────────────────────
   # Runs on PRs + manual dispatch. Shows what would change before applying.
   # NOTE: Learner Lab creds expire every ~4-8 hrs — update secrets before running.
+  # ── Bootstrap (one-time, manual only) ───────────────────────────────────────
+  # Creates the S3 bucket that stores Terraform state.
+  # Must run once before any plan/apply. Idempotent — safe to re-run.
+  bootstrap:
+    name: Bootstrap state bucket
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'bootstrap'
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+      AWS_DEFAULT_REGION: us-west-2
+
+    steps:
+      - name: Create S3 state bucket (idempotent)
+        run: |
+          if aws s3api head-bucket --bucket flair2-terraform-state 2>/dev/null; then
+            echo "Bucket already exists — skipping creation"
+          else
+            aws s3api create-bucket \
+              --bucket flair2-terraform-state \
+              --region us-west-2 \
+              --create-bucket-configuration LocationConstraint=us-west-2
+            aws s3api put-bucket-versioning \
+              --bucket flair2-terraform-state \
+              --versioning-configuration Status=Enabled
+            echo "Bucket created and versioning enabled"
+          fi
+
+  # ── Plan (needs AWS creds) ───────────────────────────────────────────────────
+  # Runs on PRs + manual dispatch. Shows what would change before applying.
+  # NOTE: Learner Lab creds expire every ~4-8 hrs — update secrets before running.
   plan:
     name: Plan (dev)
     runs-on: ubuntu-latest
     needs: validate
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action != 'apply')
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'plan')
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- Adds a `bootstrap` option to the `workflow_dispatch` trigger in `terraform.yml`
- Creates the `flair2-terraform-state` S3 bucket with versioning enabled
- Idempotent: skips if bucket already exists
- No local AWS CLI needed — triggered from GitHub Actions UI

## Why
Terraform requires the S3 state bucket to exist before `init` can run, but Terraform itself can't create it (bootstrap problem). This job solves that without requiring manual CLI commands.

## Usage
1. Update GitHub Secrets with fresh Learner Lab credentials
2. GitHub Actions → Terraform → Run workflow → select `bootstrap`
3. Run once per AWS account — bucket persists across Learner Lab sessions

## Test plan
- [ ] Sam: trigger bootstrap job, confirm bucket created in AWS console
- [ ] Then trigger plan job — should init successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)