### PR TITLE
fix: gate Lambda on enable_lambda flag to unblock Terraform CI

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -275,4 +275,6 @@ module "lambda" {
   env                = var.env
   execution_role_arn = module.iam.lambda_role_arn
   s3_bucket_name     = module.s3.bucket_name
+
+  enable_lambda = false # set to true only when deploying the real artifact
 }

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -21,6 +21,8 @@ resource "aws_cloudwatch_log_group" "lambda" {
 # actual code is deployed separately via CI/CD (aws lambda update-function-code).
 
 resource "aws_lambda_function" "s7_video_gen" {
+  count = var.enable_lambda ? 1 : 0
+
   function_name = local.function_name
   role          = var.execution_role_arn
 

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -1,14 +1,14 @@
 output "function_name" {
   description = "Lambda function name for S7 video generation"
-  value       = aws_lambda_function.s7_video_gen.function_name
+  value       = var.enable_lambda ? aws_lambda_function.s7_video_gen[0].function_name : null
 }
 
 output "function_arn" {
   description = "Lambda function ARN"
-  value       = aws_lambda_function.s7_video_gen.arn
+  value       = var.enable_lambda ? aws_lambda_function.s7_video_gen[0].arn : null
 }
 
 output "invoke_arn" {
   description = "Lambda invoke ARN (used for API Gateway integration if added later)"
-  value       = aws_lambda_function.s7_video_gen.invoke_arn
+  value       = var.enable_lambda ? aws_lambda_function.s7_video_gen[0].invoke_arn : null
 }

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -29,3 +29,9 @@ variable "memory_size" {
   type        = number
   default     = 512
 }
+
+variable "enable_lambda" {
+  description = "Set to false in CI/plan to skip Lambda creation (no placeholder.zip needed). Set to true only when deploying the real artifact."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Problem
`terraform validate` was failing in CI (exit code 3) because `aws_lambda_function.s7_video_gen` unconditionally references `${path.module}/placeholder.zip` — Terraform reads this file at validate/plan time to compute a source hash, but the file doesn't exist in CI.

## Fix
Add `count = var.enable_lambda ? 1 : 0` to the Lambda resource. When `false`, Terraform skips the resource entirely and never tries to read the zip.

**Changed files (4, minimal):**
- `modules/lambda/variables.tf` — adds `enable_lambda` (bool, default `false`)
- `modules/lambda/main.tf` — adds `count` gate
- `modules/lambda/outputs.tf` — all 3 outputs use `[0]` index + null fallback when disabled
- `main.tf` — passes `enable_lambda = false` with explanatory comment

## Note
Closes #59 (replaces Copilot's PR which had a bad base and incorrectly gitignored `.terraform.lock.hcl`).

## Test plan
- [ ] `terraform validate` passes in CI
- [ ] Terraform plan job passes
- [ ] When ready to deploy real Lambda: set `enable_lambda = true` in `main.tf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)