### PR TITLE
fix: add FLAIR2_ prefix to all ECS environment variable names

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -54,9 +54,9 @@ resource "aws_ecs_task_definition" "api" {
     }]
 
     environment = [
-      { name = "REDIS_URL", value = var.redis_url },
-      { name = "S3_BUCKET", value = var.s3_bucket_name },
-      { name = "ENV", value = var.env }
+      { name = "FLAIR2_REDIS_URL", value = var.redis_url },
+      { name = "FLAIR2_S3_BUCKET", value = var.s3_bucket_name },
+      { name = "FLAIR2_ENVIRONMENT", value = var.env }
     ]
 
     secrets = [
@@ -144,9 +144,9 @@ resource "aws_ecs_task_definition" "worker" {
     ]
 
     environment = [
-      { name = "REDIS_URL", value = var.redis_url },
-      { name = "S3_BUCKET", value = var.s3_bucket_name },
-      { name = "ENV", value = var.env }
+      { name = "FLAIR2_REDIS_URL", value = var.redis_url },
+      { name = "FLAIR2_S3_BUCKET", value = var.s3_bucket_name },
+      { name = "FLAIR2_ENVIRONMENT", value = var.env }
     ]
 
     secrets = [


### PR DESCRIPTION
## Problem

Same class of bug as PR #64 — `app/config.py` uses `env_prefix="FLAIR2_"`, so pydantic-settings only reads vars that carry the prefix. The three non-secret env vars in both ECS task definitions were missing it:

| Before | After | Config field |
|--------|-------|--------------|
| `ENV` | `FLAIR2_ENVIRONMENT` | `settings.environment` |
| `REDIS_URL` | `FLAIR2_REDIS_URL` | `settings.redis_url` (M3) |
| `S3_BUCKET` | `FLAIR2_S3_BUCKET` | `settings.s3_bucket` (M3) |

Without this fix the containers would start without crashing, but `settings.environment` would silently stay `"dev"` regardless of the tfvar, and the Redis/S3 fields added in M3 would always fall back to empty string.

## Changes

- `terraform/modules/ecs/main.tf` — rename env vars in both API and Celery worker task definitions (6 lines)

## Test plan
- [ ] `terraform validate` passes (CI)
- [ ] After `terraform apply`: confirm env vars visible in ECS console → task definition → container → environment