### PR TITLE
fix: use OpenAI default_headers for Kimi User-Agent

### DIFF
--- a/backend/app/providers/kimi.py
+++ b/backend/app/providers/kimi.py
@@ -31,17 +31,13 @@ class KimiProvider:
 
     def _get_client(self):
         if self._client is None:
-            import httpx
             from openai import OpenAI
 
-            http_client = httpx.Client(
-                headers={"User-Agent": KIMI_USER_AGENT},
-                timeout=120.0,
-            )
             self._client = OpenAI(
                 api_key=self._api_key,
                 base_url=KIMI_BASE_URL,
-                http_client=http_client,
+                default_headers={"User-Agent": KIMI_USER_AGENT},
+                timeout=120.0,
             )
         return self._client
 


### PR DESCRIPTION
## Problem

Kimi's API rejects requests without a recognized coding agent User-Agent header (403 `access_terminated_error`). Our KimiProvider set the header via `httpx.Client(headers=...)`, but the OpenAI SDK overwrites it with its own User-Agent.

## Fix

Use `default_headers` on the OpenAI client instead — these merge into every request without being overwritten.

## Verified

Full pipeline run with real Kimi API: 2 videos, 8 API calls, ~19K tokens, 2 personalized results.

## Test plan

- [x] 45 tests pass
- [x] Real pipeline run succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)