### PR TITLE
feat: Runs list + Insights dashboard pages (M4-B)

### DIFF
--- a/frontend/src/pages/insights.astro
+++ b/frontend/src/pages/insights.astro
@@ -1,0 +1,150 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Insights — Flair2">
+  <div class="mx-auto max-w-3xl">
+    <h1 class="mb-2 text-3xl font-bold">Insights</h1>
+    <p class="mb-8 text-sm text-[var(--color-text-muted)]">
+      Aggregated performance across all your campaigns.
+    </p>
+
+    <!-- Loading -->
+    <div id="loading" class="grid grid-cols-3 gap-6">
+      {Array.from({ length: 3 }).map(() => (
+        <div class="h-24 animate-pulse rounded-xl bg-[var(--color-surface)]" />
+      ))}
+    </div>
+
+    <!-- Error -->
+    <div
+      id="error-state"
+      class="hidden rounded-lg border border-[var(--color-error)] bg-[var(--color-error)]/10 px-4 py-3 text-sm text-[var(--color-error)]"
+    >
+    </div>
+
+    <!-- Content -->
+    <div id="content" class="hidden flex-col gap-8">
+      <!-- Stat cards -->
+      <div class="grid grid-cols-3 gap-6">
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
+          <p class="text-xs text-[var(--color-text-muted)]">Videos Tracked</p>
+          <p id="stat-videos" class="mt-1 text-3xl font-bold">—</p>
+        </div>
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
+          <p class="text-xs text-[var(--color-text-muted)]">Prediction Accuracy</p>
+          <p id="stat-accuracy" class="mt-1 text-3xl font-bold">—</p>
+        </div>
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
+          <p class="text-xs text-[var(--color-text-muted)]">Top Patterns</p>
+          <p id="stat-patterns" class="mt-1 text-3xl font-bold">—</p>
+        </div>
+      </div>
+
+      <!-- Top patterns table -->
+      <section class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+        <h2 class="mb-4 text-lg font-semibold">Top Patterns by Performance</h2>
+        <div id="patterns-container">
+          <p class="text-sm text-[var(--color-text-muted)]">No pattern data yet — submit performance data to see results.</p>
+        </div>
+      </section>
+
+      <!-- Committee vs actual -->
+      <section class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+        <h2 class="mb-1 text-lg font-semibold">Committee Prediction vs Actual</h2>
+        <p class="mb-4 text-xs text-[var(--color-text-muted)]">How well AI persona votes correlate with real video performance.</p>
+        <div id="prediction-container">
+          <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
+            Scatter chart will appear here once performance data is collected.
+          </div>
+        </div>
+      </section>
+
+      <!-- Improvement over iterations -->
+      <section class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+        <h2 class="mb-1 text-lg font-semibold">Improvement Over Iterations</h2>
+        <p class="mb-4 text-xs text-[var(--color-text-muted)]">Average performance score per campaign run.</p>
+        <div id="iterations-container">
+          <div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
+            Line chart will appear here after multiple campaigns are tracked.
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</BaseLayout>
+
+<script>
+  import { getInsights } from "../lib/api-client";
+
+  const loadingEl = document.getElementById("loading");
+  const errorEl = document.getElementById("error-state");
+  const contentEl = document.getElementById("content");
+
+  function show(el) {
+    el.classList.remove("hidden");
+    if (el === contentEl) el.classList.add("flex");
+  }
+  function hide(el) {
+    el.classList.add("hidden");
+    if (el === contentEl) el.classList.remove("flex");
+  }
+
+  function escHtml(str) {
+    return String(str ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  async function load() {
+    try {
+      const insights = await getInsights();
+      hide(loadingEl);
+
+      document.getElementById("stat-videos").textContent =
+        insights.total_videos_tracked?.toString() ?? "0";
+
+      document.getElementById("stat-accuracy").textContent =
+        insights.prediction_accuracy != null
+          ? `${(insights.prediction_accuracy * 100).toFixed(1)}%`
+          : "N/A";
+
+      const patterns = insights.top_patterns ?? [];
+      document.getElementById("stat-patterns").textContent = patterns.length.toString();
+
+      if (patterns.length > 0) {
+        const rows = patterns
+          .map(
+            (p, i) => `
+              <tr class="border-t border-[var(--color-border)]">
+                <td class="py-2 pr-4 text-sm font-mono text-[var(--color-text-muted)]">${i + 1}</td>
+                <td class="py-2 text-sm">${escHtml(typeof p === "string" ? p : JSON.stringify(p))}</td>
+              </tr>
+            `,
+          )
+          .join("");
+
+        document.getElementById("patterns-container").innerHTML = `
+          <table class="w-full">
+            <thead>
+              <tr class="text-left text-xs text-[var(--color-text-muted)]">
+                <th class="pb-2 pr-4">#</th>
+                <th class="pb-2">Pattern</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        `;
+      }
+
+      show(contentEl);
+    } catch (err) {
+      hide(loadingEl);
+      errorEl.textContent = `Could not load insights: ${err instanceof Error ? err.message : "Unknown error"}`;
+      show(errorEl);
+    }
+  }
+
+  load();
+</script>

--- a/frontend/src/pages/runs.astro
+++ b/frontend/src/pages/runs.astro
@@ -1,0 +1,141 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Runs — Flair2">
+  <div class="mx-auto max-w-3xl">
+    <div class="mb-8 flex items-center justify-between">
+      <div>
+        <h1 class="text-3xl font-bold">Runs</h1>
+        <p class="mt-1 text-sm text-[var(--color-text-muted)]">
+          All pipeline runs in this session.
+        </p>
+      </div>
+      <a
+        href="/create"
+        class="rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--color-accent-hover)]"
+      >
+        + New Run
+      </a>
+    </div>
+
+    <!-- Loading -->
+    <div id="loading" class="flex flex-col gap-3">
+      {Array.from({ length: 4 }).map(() => (
+        <div class="h-16 animate-pulse rounded-xl bg-[var(--color-surface)]" />
+      ))}
+    </div>
+
+    <!-- Error -->
+    <div
+      id="error-state"
+      class="hidden rounded-lg border border-[var(--color-error)] bg-[var(--color-error)]/10 px-4 py-3 text-sm text-[var(--color-error)]"
+    >
+    </div>
+
+    <!-- Runs table -->
+    <div id="runs-list" class="hidden flex-col gap-3"></div>
+
+    <!-- Empty -->
+    <div id="empty-state" class="hidden py-20 text-center">
+      <p class="text-lg text-[var(--color-text-muted)]">No runs yet.</p>
+      <a
+        href="/create"
+        class="mt-4 inline-block rounded-lg bg-[var(--color-accent)] px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[var(--color-accent-hover)]"
+      >
+        Create your first campaign
+      </a>
+    </div>
+  </div>
+</BaseLayout>
+
+<script>
+  import { listRuns } from "../lib/api-client";
+
+  const loadingEl = document.getElementById("loading");
+  const errorEl = document.getElementById("error-state");
+  const listEl = document.getElementById("runs-list");
+  const emptyEl = document.getElementById("empty-state");
+
+  function show(el) {
+    el.classList.remove("hidden");
+    if (el === listEl) el.classList.add("flex");
+  }
+  function hide(el) {
+    el.classList.add("hidden");
+    if (el === listEl) el.classList.remove("flex");
+  }
+
+  const STATUS_STYLES = {
+    pending:   "bg-[var(--color-warning)]/15 text-[var(--color-warning)]",
+    running:   "bg-[var(--color-accent)]/15 text-[var(--color-accent)]",
+    completed: "bg-[var(--color-success)]/15 text-[var(--color-success)]",
+    failed:    "bg-[var(--color-error)]/15 text-[var(--color-error)]",
+  };
+
+  function runLink(run) {
+    if (run.status === "completed") return `/track/${run.run_id}`;
+    if (run.status === "failed") return `/pipeline/${run.run_id}`;
+    return `/pipeline/${run.run_id}`;
+  }
+
+  function formatDate(iso) {
+    if (!iso) return "—";
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  function buildRow(run) {
+    const el = document.createElement("a");
+    el.href = runLink(run);
+    el.className =
+      "flex items-center justify-between rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-5 py-4 transition-colors hover:border-[var(--color-accent)]";
+
+    const statusClass = STATUS_STYLES[run.status] ?? STATUS_STYLES.pending;
+    const shortId = run.run_id.slice(0, 8) + "…";
+
+    el.innerHTML = `
+      <div class="flex items-center gap-4">
+        <span class="font-mono text-sm text-[var(--color-text-muted)]">${shortId}</span>
+        <span class="rounded-full px-2.5 py-0.5 text-xs font-medium ${statusClass}">
+          ${run.status}
+        </span>
+      </div>
+      <div class="flex items-center gap-6 text-sm text-[var(--color-text-muted)]">
+        ${run.current_stage ? `<span>Stage: ${run.current_stage}</span>` : ""}
+        <span>→</span>
+      </div>
+    `;
+
+    return el;
+  }
+
+  async function load() {
+    try {
+      const { runs } = await listRuns();
+      hide(loadingEl);
+
+      if (!runs || runs.length === 0) {
+        show(emptyEl);
+        return;
+      }
+
+      // Sort newest first (API doesn't guarantee order)
+      const sorted = [...runs].reverse();
+      for (const run of sorted) {
+        listEl.appendChild(buildRow(run));
+      }
+      show(listEl);
+    } catch (err) {
+      hide(loadingEl);
+      errorEl.textContent = `Could not load runs: ${err instanceof Error ? err.message : "Unknown error"}`;
+      show(errorEl);
+    }
+  }
+
+  load();
+</script>


### PR DESCRIPTION
## Summary

**`pages/runs.astro`**
- Lists all session runs via `listRuns()` (session ID from localStorage)
- Each row: truncated run_id, color-coded status badge (pending/running/completed/failed), current stage, arrow link
- Links to `/track/{id}` for completed runs, `/pipeline/{id}` for all others
- Empty state with "Create your first campaign" CTA
- "+ New Run" button in header

**`pages/insights.astro`**
- Loads `getInsights()` on mount
- Stat cards: total videos tracked, prediction accuracy (%), pattern count
- Top patterns table (renders if data exists, placeholder if empty)
- Placeholder sections for committee prediction vs actual and iteration improvement — layout ready for chart data when backend insights endpoint is fleshed out

## Test plan

- [ ] `/runs` shows all session runs
- [ ] Status badges are correct colors
- [ ] Completed run links to `/track/{id}`, in-progress links to `/pipeline/{id}`
- [ ] Empty state shows when no runs
- [ ] `/insights` renders stat cards from API
- [ ] Pattern table renders when patterns exist
- [ ] Both pages show error state when API is down

Part of #80 (M4-B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)