### PR TITLE
feat: pipeline visualizer, voting animation, results page (M4-A)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,19 +31,19 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS — allow frontend origins in dev
-# Astro dev server (4321) and fallback (3000) in debug mode
+# CORS — allow frontend origins in dev, lock down in production.
+# Astro dev server auto-increments port when 4321 is taken, so we
+# cover the common range. Production uses same-origin (no CORS needed).
 _DEV_ORIGINS = [
-    "http://localhost:4321",
-    "http://localhost:4322",
-    "http://localhost:4323",
-    "http://localhost:4324",
-    "http://localhost:3000",
+    f"http://localhost:{port}"
+    for port in [3000, 4321, 4322, 4323, 4324, 5173]
 ]
+
+_is_dev = settings.environment == "dev"
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_DEV_ORIGINS if settings.debug else [],
+    allow_origins=_DEV_ORIGINS if _is_dev else [],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,7 +33,13 @@ app = FastAPI(
 
 # CORS — allow frontend origins in dev
 # Astro dev server (4321) and fallback (3000) in debug mode
-_DEV_ORIGINS = ["http://localhost:4321", "http://localhost:3000"]
+_DEV_ORIGINS = [
+    "http://localhost:4321",
+    "http://localhost:4322",
+    "http://localhost:4323",
+    "http://localhost:4324",
+    "http://localhost:3000",
+]
 
 app.add_middleware(
     CORSMiddleware,

--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -1,8 +1,10 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
+import cloudflare from "@astrojs/cloudflare";
 
 export default defineConfig({
+  adapter: cloudflare(),
   integrations: [react()],
   vite: {
     css: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "flair2-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/cloudflare": "^13.1.8",
         "@astrojs/react": "^4.2.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -54,6 +55,98 @@
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@astrojs/cloudflare": {
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-13.1.8.tgz",
+      "integrity": "sha512-X686k+2Rg5oiuQn7Df1tJyyxOiCu0PgBTYaQ3UcTmS4AfKz55g2O1iJvHZmzjqcCll2rO0oCH0Ba9gey1kg5cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.8.0",
+        "@astrojs/underscore-redirects": "1.0.3",
+        "@cloudflare/vite-plugin": "^1.25.6",
+        "piccolore": "^0.1.3",
+        "tinyglobby": "^0.2.15",
+        "vite": "^7.3.1"
+      },
+      "peerDependencies": {
+        "astro": "^6.0.0",
+        "wrangler": "^4.61.1"
+      }
+    },
+    "node_modules/@astrojs/cloudflare/node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -192,6 +285,12 @@
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
+    },
+    "node_modules/@astrojs/underscore-redirects": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.3.tgz",
+      "integrity": "sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/yaml2ts": {
       "version": "0.2.3",
@@ -498,6 +597,149 @@
         "fast-string-width": "^1.1.0",
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin": {
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.31.2.tgz",
+      "integrity": "sha512-6RyoPhqmpuHPB+Zudt7mOUdGzB1+DQtJtPdAxUajhlS2ZUU0+bCn9Cj4g6Z2EvajBrkBTw1yVLqtt4bsUnp1Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/unenv-preset": "2.16.0",
+        "miniflare": "4.20260409.0",
+        "unenv": "2.0.0-rc.24",
+        "wrangler": "4.81.1",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
+        "wrangler": "^4.81.1"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260409.1.tgz",
+      "integrity": "sha512-h/bkaC0HJL63aqAGnV0oagqpBiTSstabODThkeMSbG8kctl0Jb4jlq1pNHJPmYGazFNtfyagrUZFb6HN22GX7w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260409.1.tgz",
+      "integrity": "sha512-HTAC+B9uSYcm+GjN3UYJjuun19GqYtK1bAFJ0KECXyfsgIDwH1MTzxbTxzJpZUbWLw8s0jcwCU06MWZj6cgnxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260409.1.tgz",
+      "integrity": "sha512-QIoNq5cgmn1ko8qlngmgZLXQr2KglrjvIwVFOyJI3rbIpt8631n/YMzHPiOWgt38Cb6tcni8fXOzkcvIX2lBDg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260409.1.tgz",
+      "integrity": "sha512-HJGBMTfPDb0GCjwdxWFx63wS20TYDVmtOuA5KVri/CiFnit71y++kmseVmemjsgLFFIzoEAuFG/xUh1FJLo6tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260409.1.tgz",
+      "integrity": "sha512-GttFO0+TvE0rJNQbDlxC6kq2Q7uFxoZRo74Z9d/trUrLgA14HEVTTXobYyiWrDZ9Qp2W5KN1CrXQXiko0zE38Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -993,7 +1235,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -1543,6 +1784,32 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1995,6 +2262,24 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2606,6 +2891,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3014,7 +3305,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3176,6 +3466,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-module-lexer": {
@@ -3955,7 +4254,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4861,6 +5159,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/miniflare": {
+      "version": "4.20260409.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260409.0.tgz",
+      "integrity": "sha512-ayl6To4av0YuXsSivGgWLj+Ug8xZ0Qz3sGV8+Ok2LhNVl6m8m5ktEBM3LX9iT9MtLZRJwBlJrKcraNs/DlZQfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.4",
+        "workerd": "1.20260409.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
@@ -5144,6 +5462,18 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
     "node_modules/piccolore": {
@@ -5852,7 +6182,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -5896,7 +6225,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6033,6 +6361,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -6365,6 +6705,24 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -7568,6 +7926,517 @@
         "node": ">=4"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260409.1.tgz",
+      "integrity": "sha512-kuWP20fAaqaLBqLbvUfY9nCF6c3C78L60G9lS6eVwBf+v8trVFIsAdLB/FtrnKm7vgVvpDzvFAfB80VIiVj95w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260409.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260409.1",
+        "@cloudflare/workerd-linux-64": "1.20260409.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260409.1",
+        "@cloudflare/workerd-windows-64": "1.20260409.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.81.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.81.1.tgz",
+      "integrity": "sha512-fppPXi+W2KJ5bx1zxdUYe1e7CHj5cWPFVBPXy8hSMZhrHeIojMe3ozAktAOw1voVuQjXzbZJf/GVKyVeSjbF8w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260409.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260409.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260409.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7584,6 +8453,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xxhash-wasm": {
@@ -7715,6 +8605,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     },
     "node_modules/zod": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,19 +9,20 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^6.1.4",
+    "@astrojs/cloudflare": "^13.1.8",
     "@astrojs/react": "^4.2.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "framer-motion": "^12.6.5",
     "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2"
+    "@types/react-dom": "^19.1.2",
+    "astro": "^6.1.4",
+    "framer-motion": "^12.6.5",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
-    "tailwindcss": "^3.4.17",
-    "postcss": "^8.5.3",
     "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3"
   }
 }

--- a/frontend/src/components/PipelineVisualizer.tsx
+++ b/frontend/src/components/PipelineVisualizer.tsx
@@ -1,0 +1,414 @@
+/**
+ * Pipeline Visualizer — SSE-connected React island.
+ *
+ * Renders the 7-stage pipeline as connected nodes:
+ *   Discover → Aggregate → Generate → Vote → Rank → Personalize → Done
+ *
+ * Derives all state from the useSSE event stream.
+ * Framer Motion animates stage transitions, progress fills, and checkmarks.
+ *
+ * Issue: https://github.com/yangyang-how/flair2/issues/36
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useSSE, type SSEEvent } from "../lib/sse-client";
+import { Badge, ProgressBar } from "./ui";
+
+// ── Stage definitions ─────────────────────────────────────
+
+interface StageInfo {
+  id: string;
+  label: string;
+  description: string;
+}
+
+const STAGES: StageInfo[] = [
+  { id: "S1_MAP", label: "Discover", description: "Analyzing viral videos" },
+  { id: "S2_REDUCE", label: "Aggregate", description: "Extracting patterns" },
+  { id: "S3_SEQUENTIAL", label: "Generate", description: "Writing scripts" },
+  { id: "S4_MAP", label: "Vote", description: "100 personas voting" },
+  { id: "S5_REDUCE", label: "Rank", description: "Tallying results" },
+  { id: "S6_PERSONALIZE", label: "Personalize", description: "Adapting to your voice" },
+];
+
+type StageStatus = "pending" | "running" | "completed" | "failed";
+
+interface StageState {
+  status: StageStatus;
+  progress: number; // 0-100
+  detail: string;   // e.g. "42/100 videos"
+}
+
+function initialStageStates(): Record<string, StageState> {
+  const states: Record<string, StageState> = {};
+  for (const stage of STAGES) {
+    states[stage.id] = { status: "pending", progress: 0, detail: "" };
+  }
+  return states;
+}
+
+// ── Derive stage states from SSE events ───────────────────
+
+function deriveStageStates(events: SSEEvent[]): {
+  stages: Record<string, StageState>;
+  pipelineDone: boolean;
+  pipelineError: string | null;
+  runId: string | null;
+} {
+  const stages = initialStageStates();
+  let pipelineDone = false;
+  let pipelineError: string | null = null;
+  let runId: string | null = null;
+
+  for (const evt of events) {
+    const d = evt.data as Record<string, unknown>;
+
+    switch (evt.event) {
+      case "pipeline_started":
+        runId = (d.run_id as string) || null;
+        break;
+
+      case "stage_started": {
+        const stageId = d.stage as string;
+        if (stages[stageId]) {
+          // Mark all prior stages as completed
+          for (const s of STAGES) {
+            if (s.id === stageId) break;
+            if (stages[s.id].status !== "completed") {
+              stages[s.id] = { status: "completed", progress: 100, detail: "" };
+            }
+          }
+          stages[stageId] = {
+            status: "running",
+            progress: 0,
+            detail: d.total_items ? `0/${d.total_items}` : "",
+          };
+        }
+        break;
+      }
+
+      case "s1_progress": {
+        const completed = d.completed as number;
+        const total = d.total as number;
+        stages.S1_MAP = {
+          status: "running",
+          progress: total > 0 ? (completed / total) * 100 : 0,
+          detail: `${completed}/${total} videos`,
+        };
+        break;
+      }
+
+      case "s2_complete":
+        stages.S2_REDUCE = {
+          status: "completed",
+          progress: 100,
+          detail: `${d.pattern_count ?? ""} patterns`,
+        };
+        break;
+
+      case "s3_progress": {
+        const completed = d.completed as number;
+        const total = d.total as number;
+        stages.S3_SEQUENTIAL = {
+          status: "running",
+          progress: total > 0 ? (completed / total) * 100 : 0,
+          detail: `${completed}/${total} scripts`,
+        };
+        break;
+      }
+
+      case "s3_complete":
+        stages.S3_SEQUENTIAL = {
+          status: "completed",
+          progress: 100,
+          detail: `${d.script_count ?? ""} scripts`,
+        };
+        break;
+
+      case "vote_cast": {
+        const completed = d.completed as number;
+        const total = d.total as number;
+        stages.S4_MAP = {
+          status: "running",
+          progress: total > 0 ? (completed / total) * 100 : 0,
+          detail: `${completed}/${total} votes`,
+        };
+        break;
+      }
+
+      case "s5_complete":
+        stages.S5_REDUCE = {
+          status: "completed",
+          progress: 100,
+          detail: `Top ${d.top_n ?? ""}`,
+        };
+        break;
+
+      case "s6_progress": {
+        const completed = d.completed as number;
+        const total = d.total as number;
+        stages.S6_PERSONALIZE = {
+          status: "running",
+          progress: total > 0 ? (completed / total) * 100 : 0,
+          detail: `${completed}/${total} scripts`,
+        };
+        break;
+      }
+
+      case "pipeline_complete":
+        pipelineDone = true;
+        // Mark all stages as completed
+        for (const s of STAGES) {
+          stages[s.id] = { status: "completed", progress: 100, detail: stages[s.id].detail };
+        }
+        break;
+
+      case "pipeline_error":
+        pipelineError = (d.error as string) || "Pipeline failed";
+        // Mark current running stage as failed
+        for (const s of STAGES) {
+          if (stages[s.id].status === "running") {
+            stages[s.id] = { ...stages[s.id], status: "failed" };
+          }
+        }
+        break;
+    }
+  }
+
+  return { stages, pipelineDone, pipelineError, runId };
+}
+
+// ── Component ─────────────────────────────────────────────
+
+interface PipelineVisualizerProps {
+  runId: string;
+}
+
+export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
+  const { events, connected, error } = useSSE(runId);
+  const [redirecting, setRedirecting] = useState(false);
+
+  const { stages, pipelineDone, pipelineError } = useMemo(
+    () => deriveStageStates(events),
+    [events],
+  );
+
+  // Auto-redirect to vote page on completion
+  useEffect(() => {
+    if (pipelineDone && !redirecting) {
+      setRedirecting(true);
+      const timer = setTimeout(() => {
+        window.location.href = `/vote/${runId}`;
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [pipelineDone, runId, redirecting]);
+
+  return (
+    <div className="space-y-6">
+      {/* Connection status */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Pipeline Progress</h2>
+        <div className="flex items-center gap-2">
+          <span
+            className={`h-2 w-2 rounded-full ${
+              connected ? "bg-[var(--color-success)]" : "bg-[var(--color-error)]"
+            }`}
+          />
+          <span className="text-xs text-[var(--color-text-muted)]">
+            {connected ? "Connected" : error || "Disconnected"}
+          </span>
+        </div>
+      </div>
+
+      {/* Stage nodes */}
+      <div className="space-y-3">
+        {STAGES.map((stage, i) => {
+          const state = stages[stage.id];
+          return (
+            <StageNode
+              key={stage.id}
+              stage={stage}
+              state={state}
+              isLast={i === STAGES.length - 1}
+            />
+          );
+        })}
+
+        {/* Done node */}
+        <motion.div
+          initial={{ opacity: 0.3 }}
+          animate={{ opacity: pipelineDone ? 1 : 0.3 }}
+          className="flex items-center gap-3 pl-2"
+        >
+          <div
+            className={`flex h-8 w-8 items-center justify-center rounded-full border-2 ${
+              pipelineDone
+                ? "border-[var(--color-success)] bg-[var(--color-success)]/10"
+                : "border-[var(--color-border)]"
+            }`}
+          >
+            {pipelineDone && (
+              <motion.svg
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                className="h-4 w-4 text-[var(--color-success)]"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </motion.svg>
+            )}
+          </div>
+          <span className={`font-medium ${pipelineDone ? "text-[var(--color-success)]" : "text-[var(--color-text-muted)]"}`}>
+            Done
+          </span>
+        </motion.div>
+      </div>
+
+      {/* Error banner */}
+      <AnimatePresence>
+        {pipelineError && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/5 p-4"
+          >
+            <p className="text-sm font-medium text-[var(--color-error)]">
+              Pipeline Error
+            </p>
+            <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+              {pipelineError}
+            </p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Redirect notice */}
+      <AnimatePresence>
+        {pipelineDone && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-4 text-center"
+          >
+            <p className="text-sm text-[var(--color-success)]">
+              Pipeline complete — redirecting to voting results...
+            </p>
+            <a
+              href={`/vote/${runId}`}
+              className="mt-2 inline-block text-sm text-[var(--color-accent)] hover:underline"
+            >
+              Go now
+            </a>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Stage Node ────────────────────────────────────────────
+
+function StageNode({
+  stage,
+  state,
+  isLast,
+}: {
+  stage: StageInfo;
+  state: StageState;
+  isLast: boolean;
+}) {
+  const badgeStatus = state.status;
+
+  return (
+    <div className="relative">
+      {/* Connector line */}
+      {!isLast && (
+        <div className="absolute left-[19px] top-10 h-[calc(100%)] w-px bg-[var(--color-border)]" />
+      )}
+
+      <motion.div
+        layout
+        className={`flex items-start gap-3 rounded-lg p-2 transition-colors ${
+          state.status === "running" ? "bg-[var(--color-surface)]" : ""
+        }`}
+      >
+        {/* Circle indicator */}
+        <div className="relative z-10 mt-0.5">
+          <motion.div
+            className={`flex h-8 w-8 items-center justify-center rounded-full border-2 transition-colors ${
+              state.status === "completed"
+                ? "border-[var(--color-success)] bg-[var(--color-success)]/10"
+                : state.status === "running"
+                  ? "border-[var(--color-accent)] bg-[var(--color-accent)]/10"
+                  : state.status === "failed"
+                    ? "border-[var(--color-error)] bg-[var(--color-error)]/10"
+                    : "border-[var(--color-border)] bg-transparent"
+            }`}
+          >
+            {state.status === "completed" && (
+              <motion.svg
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                className="h-4 w-4 text-[var(--color-success)]"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </motion.svg>
+            )}
+            {state.status === "running" && (
+              <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-[var(--color-accent)]" />
+            )}
+            {state.status === "failed" && (
+              <svg className="h-4 w-4 text-[var(--color-error)]" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            )}
+          </motion.div>
+        </div>
+
+        {/* Content */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{stage.label}</span>
+            <Badge status={badgeStatus} className="text-[10px]" />
+          </div>
+          <p className="mt-0.5 text-xs text-[var(--color-text-muted)]">
+            {state.detail || stage.description}
+          </p>
+
+          {/* Progress bar for running stages with fan-out */}
+          <AnimatePresence>
+            {state.status === "running" && state.progress > 0 && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                className="mt-2"
+              >
+                <ProgressBar value={state.progress} />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,0 +1,407 @@
+/**
+ * Results View — displays pipeline results with video generation.
+ *
+ * Loads final results from the API, shows ranked scripts in tabs,
+ * and provides video generation with polling.
+ *
+ * Issue: https://github.com/yangyang-how/flair2/issues/38
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  type FinalResult,
+  type PipelineResults,
+  type VideoStatus,
+  generateVideo,
+  getPipelineResults,
+  getVideoStatus,
+} from "../lib/api-client";
+import { Button, Card, Spinner, Tabs } from "./ui";
+
+// ── Component ─────────────────────────────────────────────
+
+interface ResultsViewProps {
+  runId: string;
+}
+
+export default function ResultsView({ runId }: ResultsViewProps) {
+  const [results, setResults] = useState<PipelineResults | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const data = await getPipelineResults(runId);
+        if (!cancelled) {
+          setResults(data);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load results",
+          );
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-3">
+        <Spinner size="lg" />
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Loading results...
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/5 p-6 text-center">
+        <p className="font-medium text-[var(--color-error)]">
+          Failed to load results
+        </p>
+        <p className="mt-1 text-sm text-[var(--color-text-muted)]">{error}</p>
+        <a
+          href={`/pipeline/${runId}`}
+          className="mt-3 inline-block text-sm text-[var(--color-accent)] hover:underline"
+        >
+          Check pipeline status
+        </a>
+      </div>
+    );
+  }
+
+  if (!results || results.results.length === 0) {
+    return (
+      <div className="py-20 text-center">
+        <p className="text-[var(--color-text-muted)]">
+          No results found for this run.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-xl font-semibold">Campaign Results</h2>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Top {results.results.length} scripts, ranked by audience vote
+        </p>
+      </div>
+
+      {/* Tabs: Scripts | Video Prompts */}
+      <Tabs
+        tabs={[
+          {
+            id: "scripts",
+            label: `Scripts (${results.results.length})`,
+            content: (
+              <ScriptList results={results.results} runId={runId} />
+            ),
+          },
+          {
+            id: "prompts",
+            label: "Video Prompts",
+            content: (
+              <VideoPromptList results={results.results} />
+            ),
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+// ── Script List ───────────────────────────────────────────
+
+function ScriptList({
+  results,
+  runId,
+}: {
+  results: FinalResult[];
+  runId: string;
+}) {
+  return (
+    <div className="space-y-4">
+      {results.map((result) => (
+        <ScriptCard key={result.script_id} result={result} runId={runId} />
+      ))}
+    </div>
+  );
+}
+
+// ── Script Card ───────────────────────────────────────────
+
+function ScriptCard({
+  result,
+  runId,
+}: {
+  result: FinalResult;
+  runId: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Card>
+      <div className="space-y-3">
+        {/* Rank header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span
+              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold ${
+                result.rank === 1
+                  ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)]"
+                  : "bg-[var(--color-border)] text-[var(--color-text-muted)]"
+              }`}
+            >
+              {result.rank}
+            </span>
+            <div>
+              <span className="font-mono text-xs text-[var(--color-text-muted)]">
+                {result.script_id.slice(0, 12)}
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-[var(--color-text-muted)]">
+                  Pattern: {result.original_script.pattern_used}
+                </span>
+                <span className="text-xs text-[var(--color-text-muted)]">
+                  Score: {result.vote_score.toFixed(1)}
+                </span>
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={() => setExpanded((s) => !s)}
+            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+          >
+            {expanded ? "Collapse" : "Expand"}
+          </button>
+        </div>
+
+        {/* Hook (always visible) */}
+        <div>
+          <p className="text-xs font-semibold uppercase text-[var(--color-accent)]">
+            Hook
+          </p>
+          <p className="mt-1 text-sm leading-relaxed">
+            {result.original_script.hook}
+          </p>
+        </div>
+
+        {/* Expanded content */}
+        <AnimatePresence>
+          {expanded && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              className="space-y-3 overflow-hidden"
+            >
+              {/* Body */}
+              <div>
+                <p className="text-xs font-semibold uppercase text-[var(--color-accent)]">
+                  Body
+                </p>
+                <p className="mt-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
+                  {result.original_script.body}
+                </p>
+              </div>
+
+              {/* Payoff */}
+              <div>
+                <p className="text-xs font-semibold uppercase text-[var(--color-accent)]">
+                  Payoff
+                </p>
+                <p className="mt-1 text-sm leading-relaxed">
+                  {result.original_script.payoff}
+                </p>
+              </div>
+
+              {/* Personalized version */}
+              <div className="rounded-lg bg-[var(--color-bg)] p-3">
+                <p className="text-xs font-semibold uppercase text-[var(--color-success)]">
+                  Personalized Script
+                </p>
+                <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-[var(--color-text-muted)]">
+                  {result.personalized_script}
+                </p>
+              </div>
+
+              {/* Meta */}
+              <div className="flex gap-4 text-xs text-[var(--color-text-muted)]">
+                <span>
+                  Duration: ~{result.original_script.estimated_duration.toFixed(0)}s
+                </span>
+                {result.original_script.structural_notes && (
+                  <span>Notes: {result.original_script.structural_notes}</span>
+                )}
+              </div>
+
+              {/* Video generation */}
+              <VideoGenerator runId={runId} scriptId={result.script_id} />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </Card>
+  );
+}
+
+// ── Video Prompt List ─────────────────────────────────────
+
+function VideoPromptList({ results }: { results: FinalResult[] }) {
+  return (
+    <div className="space-y-4">
+      {results.map((result) => (
+        <Card key={result.script_id}>
+          <div className="flex items-start gap-3">
+            <span
+              className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                result.rank === 1
+                  ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)]"
+                  : "bg-[var(--color-border)] text-[var(--color-text-muted)]"
+              }`}
+            >
+              {result.rank}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="whitespace-pre-wrap text-sm leading-relaxed text-[var(--color-text-muted)]">
+                {result.video_prompt}
+              </p>
+              <p className="mt-2 font-mono text-xs text-[var(--color-text-muted)]">
+                {result.script_id.slice(0, 12)} — {result.original_script.pattern_used}
+              </p>
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// ── Video Generator ───────────────────────────────────────
+
+function VideoGenerator({
+  runId,
+  scriptId,
+}: {
+  runId: string;
+  scriptId: string;
+}) {
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [status, setStatus] = useState<VideoStatus | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Clean up polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    setGenerating(true);
+    setError(null);
+
+    try {
+      const { job_id } = await generateVideo(runId, scriptId);
+      setJobId(job_id);
+
+      // Start polling
+      pollRef.current = setInterval(async () => {
+        try {
+          const vs = await getVideoStatus(runId, job_id);
+          setStatus(vs);
+
+          if (vs.status === "complete" || vs.status === "failed") {
+            if (pollRef.current) clearInterval(pollRef.current);
+            pollRef.current = null;
+            setGenerating(false);
+
+            if (vs.status === "failed") {
+              setError(vs.error || "Video generation failed");
+            }
+          }
+        } catch {
+          // Keep polling on transient errors
+        }
+      }, 5000);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to start generation",
+      );
+      setGenerating(false);
+    }
+  }, [runId, scriptId]);
+
+  return (
+    <div className="border-t border-[var(--color-border)] pt-3">
+      {!jobId && (
+        <Button
+          onClick={handleGenerate}
+          loading={generating}
+          size="sm"
+          variant="secondary"
+        >
+          Generate Video
+        </Button>
+      )}
+
+      {jobId && status?.status === "processing" && (
+        <div className="flex items-center gap-2">
+          <Spinner size="sm" />
+          <span className="text-sm text-[var(--color-text-muted)]">
+            Generating video...
+          </span>
+        </div>
+      )}
+
+      {status?.status === "complete" && status.video_url && (
+        <VideoPlayer url={status.video_url} />
+      )}
+
+      {error && (
+        <p className="mt-2 text-sm text-[var(--color-error)]">{error}</p>
+      )}
+    </div>
+  );
+}
+
+// ── Video Player ──────────────────────────────────────────
+
+function VideoPlayer({ url }: { url: string }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="overflow-hidden rounded-lg"
+    >
+      <video
+        src={url}
+        controls
+        className="w-full rounded-lg"
+        preload="metadata"
+      >
+        <track kind="captions" />
+        Your browser does not support video playback.
+      </video>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/VotingAnimation.tsx
+++ b/frontend/src/components/VotingAnimation.tsx
@@ -1,0 +1,348 @@
+/**
+ * Voting Animation — 100-avatar React island with live SSE voting.
+ *
+ * Displays a 10x10 grid of persona avatars. As vote_cast events arrive,
+ * the corresponding avatar animates and the leaderboard updates.
+ *
+ * Can show either the live voting (SSE connected) or the final results
+ * (loaded from API after pipeline completes).
+ *
+ * Issue: https://github.com/yangyang-how/flair2/issues/37
+ */
+
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useSSE, type SSEEvent } from "../lib/sse-client";
+import { Card, ProgressBar } from "./ui";
+
+// ── Types ─────────────────────────────────────────────────
+
+interface Vote {
+  personaId: string;
+  top5: string[];
+  index: number;
+}
+
+interface LeaderboardEntry {
+  scriptId: string;
+  votes: number;
+}
+
+// ── Derive voting state from SSE events ───────────────────
+
+function deriveVotingState(events: SSEEvent[]) {
+  const votes: Vote[] = [];
+  const votedSet = new Set<number>();
+  const tally: Record<string, number> = {};
+  let totalPersonas = 100;
+  let pipelineDone = false;
+  let topIds: string[] = [];
+
+  for (const evt of events) {
+    const d = evt.data as Record<string, unknown>;
+
+    switch (evt.event) {
+      case "pipeline_started":
+        totalPersonas = (d.total_personas as number) || 100;
+        break;
+
+      case "stage_started":
+        if (d.stage === "S4_MAP") {
+          totalPersonas = (d.total_items as number) || totalPersonas;
+        }
+        break;
+
+      case "vote_cast": {
+        const personaId = d.persona_id as string;
+        const top5 = (d.top_5 as string[]) || [];
+        const completed = (d.completed as number) || votes.length + 1;
+        const idx = completed - 1;
+
+        if (!votedSet.has(idx)) {
+          votedSet.add(idx);
+          votes.push({ personaId, top5, index: idx });
+
+          for (const scriptId of top5) {
+            tally[scriptId] = (tally[scriptId] || 0) + 1;
+          }
+        }
+        break;
+      }
+
+      case "s5_complete":
+        topIds = (d.top_ids as string[]) || [];
+        break;
+
+      case "pipeline_complete":
+        pipelineDone = true;
+        break;
+    }
+  }
+
+  // Build sorted leaderboard
+  const leaderboard: LeaderboardEntry[] = Object.entries(tally)
+    .map(([scriptId, voteCount]) => ({ scriptId, votes: voteCount }))
+    .sort((a, b) => b.votes - a.votes)
+    .slice(0, 10);
+
+  return {
+    votes,
+    votedSet,
+    leaderboard,
+    totalPersonas,
+    pipelineDone,
+    topIds,
+  };
+}
+
+// ── Component ─────────────────────────────────────────────
+
+interface VotingAnimationProps {
+  runId: string;
+}
+
+export default function VotingAnimation({ runId }: VotingAnimationProps) {
+  const { events, connected, error } = useSSE(runId);
+  const [showGrid, setShowGrid] = useState(true);
+
+  const {
+    votes,
+    votedSet,
+    leaderboard,
+    totalPersonas,
+    pipelineDone,
+    topIds,
+  } = useMemo(() => deriveVotingState(events), [events]);
+
+  const voteCount = votes.length;
+  const progress = totalPersonas > 0 ? (voteCount / totalPersonas) * 100 : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Audience Vote</h2>
+          <p className="text-sm text-[var(--color-text-muted)]">
+            {pipelineDone
+              ? "Voting complete — see the winners below"
+              : `${voteCount}/${totalPersonas} votes cast`}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setShowGrid((s) => !s)}
+            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+          >
+            {showGrid ? "Hide grid" : "Show grid"}
+          </button>
+          <span
+            className={`h-2 w-2 rounded-full ${
+              connected ? "bg-[var(--color-success)]" : "bg-[var(--color-error)]"
+            }`}
+          />
+        </div>
+      </div>
+
+      {/* Progress */}
+      <ProgressBar
+        value={progress}
+        label={`${voteCount} of ${totalPersonas} personas`}
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_300px]">
+        {/* Avatar grid */}
+        <AnimatePresence>
+          {showGrid && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            >
+              <AvatarGrid
+                total={totalPersonas}
+                votedSet={votedSet}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Leaderboard */}
+        <div className={showGrid ? "" : "lg:col-span-2 max-w-md mx-auto w-full"}>
+          <Leaderboard
+            entries={leaderboard}
+            topIds={topIds}
+            pipelineDone={pipelineDone}
+            maxVotes={totalPersonas}
+          />
+        </div>
+      </div>
+
+      {/* Final actions */}
+      {pipelineDone && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-4 text-center"
+        >
+          <p className="text-sm text-[var(--color-success)]">
+            Voting complete — {leaderboard[0]?.scriptId || "Script"} won with{" "}
+            {leaderboard[0]?.votes || 0} votes
+          </p>
+          <a
+            href={`/results/${runId}`}
+            className="mt-2 inline-block rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--color-accent-hover)]"
+          >
+            View Results
+          </a>
+        </motion.div>
+      )}
+
+      {/* Error */}
+      {error && !pipelineDone && (
+        <div className="rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/5 p-3">
+          <p className="text-sm text-[var(--color-error)]">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Avatar Grid ───────────────────────────────────────────
+
+function AvatarGrid({
+  total,
+  votedSet,
+}: {
+  total: number;
+  votedSet: Set<number>;
+}) {
+  // Generate stable colors for each avatar
+  const colors = useMemo(() => {
+    const hues = Array.from({ length: total }, (_, i) => (i * 137.5) % 360);
+    return hues.map((h) => `hsl(${h}, 50%, 60%)`);
+  }, [total]);
+
+  return (
+    <Card padding="sm">
+      <div
+        className="grid gap-1"
+        style={{
+          gridTemplateColumns: `repeat(${Math.min(10, Math.ceil(Math.sqrt(total)))}, 1fr)`,
+        }}
+      >
+        {Array.from({ length: total }, (_, i) => {
+          const hasVoted = votedSet.has(i);
+          return (
+            <motion.div
+              key={i}
+              className="relative aspect-square rounded-md"
+              style={{
+                backgroundColor: hasVoted ? colors[i] : "var(--color-border)",
+              }}
+              animate={
+                hasVoted
+                  ? {
+                      scale: [1, 1.2, 1],
+                      opacity: 1,
+                    }
+                  : { scale: 1, opacity: 0.3 }
+              }
+              transition={{
+                duration: 0.3,
+                ease: "easeOut",
+              }}
+            >
+              {hasVoted && (
+                <motion.div
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  className="absolute inset-0 flex items-center justify-center text-[8px] font-bold text-white/80"
+                >
+                  {i + 1}
+                </motion.div>
+              )}
+            </motion.div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+// ── Leaderboard ───────────────────────────────────────────
+
+function Leaderboard({
+  entries,
+  topIds,
+  pipelineDone,
+  maxVotes,
+}: {
+  entries: LeaderboardEntry[];
+  topIds: string[];
+  pipelineDone: boolean;
+  maxVotes: number;
+}) {
+  return (
+    <Card padding="sm">
+      <h3 className="mb-3 text-sm font-semibold text-[var(--color-text-muted)]">
+        Leaderboard
+      </h3>
+
+      {entries.length === 0 ? (
+        <p className="py-4 text-center text-sm text-[var(--color-text-muted)]">
+          Waiting for votes...
+        </p>
+      ) : (
+        <div className="space-y-2">
+          <AnimatePresence mode="popLayout">
+            {entries.map((entry, rank) => {
+              const isWinner = pipelineDone && rank === 0;
+              const isFinalTop = topIds.includes(entry.scriptId);
+              const barWidth = maxVotes > 0 ? (entry.votes / maxVotes) * 100 : 0;
+
+              return (
+                <motion.div
+                  key={entry.scriptId}
+                  layout
+                  initial={{ opacity: 0, x: -10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  className={`flex items-center gap-2 rounded-md p-1.5 text-sm ${
+                    isWinner
+                      ? "bg-[var(--color-accent)]/10 border border-[var(--color-accent)]/20"
+                      : ""
+                  }`}
+                >
+                  <span className="w-5 shrink-0 text-right text-xs font-mono text-[var(--color-text-muted)]">
+                    {rank + 1}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between">
+                      <span className="truncate font-mono text-xs">
+                        {entry.scriptId.slice(0, 8)}
+                        {isFinalTop && pipelineDone && (
+                          <span className="ml-1 text-[var(--color-success)]">*</span>
+                        )}
+                      </span>
+                      <span className="ml-2 shrink-0 text-xs font-medium text-[var(--color-text-muted)]">
+                        {entry.votes}
+                      </span>
+                    </div>
+                    <div className="mt-1 h-1 overflow-hidden rounded-full bg-[var(--color-bg)]">
+                      <motion.div
+                        className="h-full rounded-full bg-[var(--color-accent)]"
+                        initial={{ width: 0 }}
+                        animate={{ width: `${barWidth}%` }}
+                        transition={{ duration: 0.3 }}
+                      />
+                    </div>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/pages/pipeline/[id].astro
+++ b/frontend/src/pages/pipeline/[id].astro
@@ -1,0 +1,32 @@
+---
+/**
+ * Pipeline progress page — /pipeline/{runId}
+ *
+ * Wraps the PipelineVisualizer React island.
+ * The runId comes from the URL parameter.
+ */
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import PipelineVisualizer from "../../components/PipelineVisualizer";
+
+export const prerender = false;
+
+const { id } = Astro.params;
+
+if (!id) {
+  return Astro.redirect("/");
+}
+---
+
+<BaseLayout title={`Pipeline — ${id.slice(0, 8)}`}>
+  <div class="py-4">
+    <nav class="mb-6 text-sm text-[var(--color-text-muted)]">
+      <a href="/" class="hover:text-[var(--color-text)]">Home</a>
+      <span class="mx-2">/</span>
+      <a href="/runs" class="hover:text-[var(--color-text)]">Runs</a>
+      <span class="mx-2">/</span>
+      <span class="text-[var(--color-text)]">{id.slice(0, 8)}</span>
+    </nav>
+
+    <PipelineVisualizer runId={id} client:load />
+  </div>
+</BaseLayout>

--- a/frontend/src/pages/results/[id].astro
+++ b/frontend/src/pages/results/[id].astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Results page — /results/{runId}
+ *
+ * Wraps the ResultsView React island.
+ * Shows ranked scripts, personalized versions, and video generation.
+ */
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import ResultsView from "../../components/ResultsView";
+
+export const prerender = false;
+
+const { id } = Astro.params;
+
+if (!id) {
+  return Astro.redirect("/");
+}
+---
+
+<BaseLayout title={`Results — ${id.slice(0, 8)}`}>
+  <div class="py-4">
+    <nav class="mb-6 text-sm text-[var(--color-text-muted)]">
+      <a href="/" class="hover:text-[var(--color-text)]">Home</a>
+      <span class="mx-2">/</span>
+      <a href="/runs" class="hover:text-[var(--color-text)]">Runs</a>
+      <span class="mx-2">/</span>
+      <a href={`/pipeline/${id}`} class="hover:text-[var(--color-text)]">Pipeline</a>
+      <span class="mx-2">/</span>
+      <span class="text-[var(--color-text)]">Results</span>
+    </nav>
+
+    <ResultsView runId={id} client:load />
+  </div>
+</BaseLayout>

--- a/frontend/src/pages/vote/[id].astro
+++ b/frontend/src/pages/vote/[id].astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Voting page — /vote/{runId}
+ *
+ * Wraps the VotingAnimation React island.
+ * Shows the 100-avatar grid and live leaderboard.
+ */
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import VotingAnimation from "../../components/VotingAnimation";
+
+export const prerender = false;
+
+const { id } = Astro.params;
+
+if (!id) {
+  return Astro.redirect("/");
+}
+---
+
+<BaseLayout title={`Voting — ${id.slice(0, 8)}`}>
+  <div class="py-4">
+    <nav class="mb-6 text-sm text-[var(--color-text-muted)]">
+      <a href="/" class="hover:text-[var(--color-text)]">Home</a>
+      <span class="mx-2">/</span>
+      <a href="/runs" class="hover:text-[var(--color-text)]">Runs</a>
+      <span class="mx-2">/</span>
+      <a href={`/pipeline/${id}`} class="hover:text-[var(--color-text)]">Pipeline</a>
+      <span class="mx-2">/</span>
+      <span class="text-[var(--color-text)]">Vote</span>
+    </nav>
+
+    <VotingAnimation runId={id} client:load />
+  </div>
+</BaseLayout>

--- a/scripts/simulate_pipeline.py
+++ b/scripts/simulate_pipeline.py
@@ -1,0 +1,175 @@
+"""Simulate a pipeline run by injecting SSE events into Redis.
+
+Writes the same Redis keys/events the orchestrator would, but without
+needing Celery, LLM APIs, or a dataset. Used for frontend testing.
+
+Usage:
+    python scripts/simulate_pipeline.py [--run-id <uuid>] [--speed <multiplier>]
+"""
+
+import argparse
+import json
+import time
+import uuid
+
+import redis
+
+REDIS_URL = "redis://localhost:6379/0"
+
+
+def emit(r: redis.Redis, run_id: str, event: str, data: dict) -> str:
+    """Add an event to the SSE stream, matching orchestrator format."""
+    payload = json.dumps({
+        "event": event,
+        "data": data,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    })
+    msg_id = r.xadd(f"sse:{run_id}", {"payload": payload})
+    print(f"  [{msg_id}] {event}: {json.dumps(data)}")
+    return msg_id
+
+
+def simulate(run_id: str, speed: float = 1.0):
+    """Run a full pipeline simulation."""
+    r = redis.from_url(REDIS_URL, decode_responses=True)
+
+    num_videos = 10
+    num_scripts = 5
+    num_personas = 20
+    top_n = 3
+
+    # Set up run state (what the orchestrator does on start)
+    r.set(f"run:{run_id}:status", "running")
+    r.set(f"run:{run_id}:stage", "S1_MAP")
+
+    print(f"\nSimulating pipeline run: {run_id}")
+    print(f"  videos={num_videos}, scripts={num_scripts}, personas={num_personas}, top_n={top_n}")
+    print(f"  speed={speed}x\n")
+
+    delay = lambda s: time.sleep(s / speed)
+
+    # Pipeline started
+    emit(r, run_id, "pipeline_started", {
+        "run_id": run_id,
+        "total_videos": num_videos,
+        "total_personas": num_personas,
+        "top_n": top_n,
+    })
+    delay(0.5)
+
+    # S1: Discover (fan-out)
+    emit(r, run_id, "stage_started", {"stage": "S1_MAP", "total_items": num_videos})
+    for i in range(1, num_videos + 1):
+        delay(0.3)
+        emit(r, run_id, "s1_progress", {
+            "video_id": f"vid_{i:03d}",
+            "completed": i,
+            "total": num_videos,
+        })
+    r.set(f"run:{run_id}:stage", "S2_REDUCE")
+    delay(0.5)
+
+    # S2: Aggregate (single task)
+    emit(r, run_id, "stage_started", {"stage": "S2_REDUCE", "total_items": 1})
+    delay(1.0)
+    emit(r, run_id, "s2_complete", {"pattern_count": 8})
+    r.set(f"run:{run_id}:stage", "S3_SEQUENTIAL")
+    delay(0.5)
+
+    # S3: Generate scripts (sequential)
+    emit(r, run_id, "stage_started", {"stage": "S3_SEQUENTIAL", "total_items": 1})
+    delay(1.5)
+    emit(r, run_id, "s3_complete", {"script_count": num_scripts})
+
+    # Generate script IDs for voting
+    script_ids = [f"script_{uuid.uuid4().hex[:8]}" for _ in range(num_scripts)]
+    r.set(f"run:{run_id}:stage", "S4_MAP")
+    delay(0.5)
+
+    # S4: Vote (fan-out)
+    emit(r, run_id, "stage_started", {"stage": "S4_MAP", "total_items": num_personas})
+    import random
+    for i in range(1, num_personas + 1):
+        delay(0.2)
+        top_5 = random.sample(script_ids, min(5, len(script_ids)))
+        emit(r, run_id, "vote_cast", {
+            "persona_id": f"persona_{i:03d}",
+            "top_5": top_5,
+            "completed": i,
+            "total": num_personas,
+        })
+    r.set(f"run:{run_id}:stage", "S5_REDUCE")
+    delay(0.5)
+
+    # S5: Rank (single task)
+    emit(r, run_id, "stage_started", {"stage": "S5_REDUCE", "total_items": 1})
+    delay(1.0)
+    top_ids = script_ids[:top_n]
+    emit(r, run_id, "s5_complete", {"top_ids": top_ids, "top_n": top_n})
+    r.set(f"run:{run_id}:stage", "S6_PERSONALIZE")
+    delay(0.5)
+
+    # S6: Personalize (fan-out over top_n)
+    emit(r, run_id, "stage_started", {"stage": "S6_PERSONALIZE", "total_items": top_n})
+    for i in range(1, top_n + 1):
+        delay(0.5)
+        emit(r, run_id, "s6_progress", {
+            "script_id": top_ids[i - 1],
+            "completed": i,
+            "total": top_n,
+        })
+    delay(0.3)
+
+    # Write final results to Redis (what results endpoint reads)
+    results = {
+        "run_id": run_id,
+        "results": [
+            {
+                "script_id": sid,
+                "original_script": {
+                    "script_id": sid,
+                    "pattern_used": random.choice(["curiosity_gap", "hot_take", "story_hook", "challenge"]),
+                    "hook": f"You won't believe what happens when you try this {random.choice(['simple', 'weird', 'secret'])} trick...",
+                    "body": f"Here's the thing nobody tells you about content creation. The algorithm doesn't care about your production value. It cares about retention. Every second counts, and the first 3 seconds are everything.",
+                    "payoff": f"Try this on your next video and watch what happens. Comment below with your results.",
+                    "estimated_duration": random.uniform(15, 60),
+                    "structural_notes": "Opens with pattern interrupt, builds tension, closes with CTA",
+                },
+                "personalized_script": f"So like... nobody's talking about this but {random.choice(['the algorithm', 'engagement', 'watch time'])} is completely different now. I tested this on my last {random.randint(3, 10)} videos and the results are insane. Drop a comment if you want the full breakdown.",
+                "video_prompt": f"Fast-paced montage. Open on close-up of creator's face, dramatic lighting. Cut to screen recording showing analytics dashboard. Text overlay: 'THE SECRET'. Background music: trending lo-fi beat. Duration: {random.randint(15, 45)}s.",
+                "rank": rank,
+                "vote_score": round(random.uniform(5, 20), 1),
+            }
+            for rank, sid in enumerate(top_ids, 1)
+        ],
+        "creator_profile": {
+            "tone": "casual",
+            "vocabulary": ["insane", "literally", "no cap"],
+            "catchphrases": ["here's the thing", "watch this"],
+            "topics_to_avoid": ["politics"],
+            "niche": "content creation tips",
+            "audience_description": "18-25 aspiring creators",
+            "content_themes": ["growth hacks", "algorithm tips"],
+            "example_hooks": ["Stop scrolling, this is important"],
+            "recent_topics": ["TikTok algorithm changes"],
+        },
+        "completed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    r.set(f"results:final:{run_id}", json.dumps(results))
+
+    # Pipeline complete
+    r.set(f"run:{run_id}:status", "completed")
+    emit(r, run_id, "pipeline_complete", {"run_id": run_id, "result_count": top_n})
+
+    print(f"\nDone. Pipeline {run_id} completed.")
+    print(f"  View pipeline: http://localhost:4321/pipeline/{run_id}")
+    print(f"  View voting:   http://localhost:4321/vote/{run_id}")
+    print(f"  View results:  http://localhost:4321/results/{run_id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Simulate a pipeline run for frontend testing")
+    parser.add_argument("--run-id", default=str(uuid.uuid4()), help="Run ID (default: random UUID)")
+    parser.add_argument("--speed", type=float, default=2.0, help="Speed multiplier (default: 2.0)")
+    args = parser.parse_args()
+    simulate(args.run_id, args.speed)

--- a/scripts/test_frontend.py
+++ b/scripts/test_frontend.py
@@ -1,0 +1,436 @@
+"""Frontend integration tests using Playwright.
+
+Tests the three M4-A pages against a running backend + frontend.
+Requires:
+  - Redis on localhost:6379
+  - Backend on localhost:8001
+  - Frontend on localhost:4324 (with PUBLIC_API_URL=http://localhost:8001)
+
+Usage:
+    python scripts/test_frontend.py
+"""
+
+import json
+import subprocess
+import sys
+import time
+import uuid
+from threading import Thread
+
+import redis
+from playwright.sync_api import sync_playwright
+
+FRONTEND_URL = "http://localhost:4324"
+REDIS_URL = "redis://localhost:6379/0"
+SCREENSHOT_DIR = "/tmp/flair2-screenshots"
+
+r = redis.from_url(REDIS_URL, decode_responses=True)
+
+
+def emit(run_id: str, event: str, data: dict) -> str:
+    payload = json.dumps({
+        "event": event,
+        "data": data,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    })
+    return r.xadd(f"sse:{run_id}", {"payload": payload})
+
+
+def setup_completed_run() -> str:
+    """Create a completed run in Redis with full results."""
+    run_id = str(uuid.uuid4())
+    r.set(f"run:{run_id}:status", "completed")
+
+    script_ids = [f"script_{uuid.uuid4().hex[:8]}" for _ in range(3)]
+    results = {
+        "run_id": run_id,
+        "results": [
+            {
+                "script_id": sid,
+                "original_script": {
+                    "script_id": sid,
+                    "pattern_used": ["curiosity_gap", "hot_take", "story_hook"][i],
+                    "hook": f"Test hook {i+1} — this is the opening line",
+                    "body": f"Test body {i+1} — main content goes here with details",
+                    "payoff": f"Test payoff {i+1} — call to action closing",
+                    "estimated_duration": 30.0 + i * 10,
+                    "structural_notes": "Test structural notes",
+                },
+                "personalized_script": f"Personalized version of script {i+1}...",
+                "video_prompt": f"Video prompt for script {i+1}: fast cuts, dramatic lighting...",
+                "rank": i + 1,
+                "vote_score": round(20.0 - i * 3.5, 1),
+            }
+            for i, sid in enumerate(script_ids)
+        ],
+        "creator_profile": {
+            "tone": "casual",
+            "vocabulary": [],
+            "catchphrases": [],
+            "topics_to_avoid": [],
+        },
+        "completed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    r.set(f"results:final:{run_id}", json.dumps(results))
+
+    # Also add SSE events so pipeline/vote pages work
+    emit(run_id, "pipeline_started", {"run_id": run_id, "total_videos": 5, "total_personas": 10, "top_n": 3})
+    for stage in ["S1_MAP", "S2_REDUCE", "S3_SEQUENTIAL", "S4_MAP", "S5_REDUCE", "S6_PERSONALIZE"]:
+        emit(run_id, "stage_started", {"stage": stage, "total_items": 5})
+    emit(run_id, "s2_complete", {"pattern_count": 4})
+    emit(run_id, "s3_complete", {"script_count": 3})
+    for i in range(10):
+        emit(run_id, "vote_cast", {
+            "persona_id": f"p{i}",
+            "top_5": script_ids,
+            "completed": i + 1,
+            "total": 10,
+        })
+    emit(run_id, "s5_complete", {"top_ids": script_ids, "top_n": 3})
+    emit(run_id, "pipeline_complete", {"run_id": run_id, "result_count": 3})
+
+    return run_id
+
+
+def setup_live_run() -> str:
+    """Create a run that will receive events slowly (for live SSE testing)."""
+    run_id = str(uuid.uuid4())
+    r.set(f"run:{run_id}:status", "running")
+    r.set(f"run:{run_id}:stage", "S1_MAP")
+    return run_id
+
+
+def emit_live_events(run_id: str):
+    """Emit events slowly to test live SSE updates."""
+    time.sleep(1)  # Give browser time to connect
+
+    emit(run_id, "pipeline_started", {
+        "run_id": run_id, "total_videos": 5, "total_personas": 10, "top_n": 3,
+    })
+    time.sleep(0.5)
+
+    emit(run_id, "stage_started", {"stage": "S1_MAP", "total_items": 5})
+    for i in range(1, 6):
+        time.sleep(0.8)
+        emit(run_id, "s1_progress", {"video_id": f"v{i}", "completed": i, "total": 5})
+
+    time.sleep(0.5)
+    emit(run_id, "stage_started", {"stage": "S2_REDUCE", "total_items": 1})
+    time.sleep(1)
+    emit(run_id, "s2_complete", {"pattern_count": 4})
+
+    time.sleep(0.5)
+    emit(run_id, "stage_started", {"stage": "S3_SEQUENTIAL", "total_items": 1})
+    time.sleep(1)
+    emit(run_id, "s3_complete", {"script_count": 3})
+
+    r.set(f"run:{run_id}:status", "completed")
+    emit(run_id, "pipeline_complete", {"run_id": run_id, "result_count": 3})
+
+
+def run_tests():
+    import os
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+
+    passed = 0
+    failed = 0
+    errors = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1280, "height": 800})
+
+        # ── Test 1: Results page loads with completed run ──────
+        print("\n[TEST 1] Results page — completed run")
+        try:
+            run_id = setup_completed_run()
+            page = context.new_page()
+            page.goto(f"{FRONTEND_URL}/results/{run_id}")
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(2000)
+
+            page.screenshot(path=f"{SCREENSHOT_DIR}/01_results_loading.png", full_page=True)
+
+            # Check for results content
+            content = page.content()
+            has_results_heading = "Campaign Results" in content
+            has_scripts_tab = "Scripts" in content
+            has_prompts_tab = "Video Prompts" in content
+            has_hook = "Test hook 1" in content or "hook" in content.lower()
+
+            if has_results_heading and has_scripts_tab and has_prompts_tab:
+                print("  PASS: Results page loaded with tabs")
+                passed += 1
+            else:
+                msg = f"Missing: heading={has_results_heading}, scripts={has_scripts_tab}, prompts={has_prompts_tab}"
+                print(f"  FAIL: {msg}")
+                errors.append(f"Test 1: {msg}")
+                failed += 1
+
+            page.screenshot(path=f"{SCREENSHOT_DIR}/01_results_final.png", full_page=True)
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 1: {e}")
+            failed += 1
+
+        # ── Test 2: Results page — expand a script card ────────
+        print("\n[TEST 2] Results page — expand script card")
+        try:
+            run_id = setup_completed_run()
+            page = context.new_page()
+            page.goto(f"{FRONTEND_URL}/results/{run_id}")
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(2000)
+
+            # Click "Expand" button
+            expand_btn = page.locator("text=Expand").first
+            if expand_btn.is_visible():
+                expand_btn.click()
+                page.wait_for_timeout(500)
+                page.screenshot(path=f"{SCREENSHOT_DIR}/02_results_expanded.png", full_page=True)
+
+                content = page.content()
+                has_body = "Test body" in content or "Body" in content
+                has_personalized = "Personalized" in content
+                has_generate = "Generate Video" in content
+
+                if has_body and has_personalized and has_generate:
+                    print("  PASS: Script card expanded with all sections")
+                    passed += 1
+                else:
+                    msg = f"Missing: body={has_body}, personalized={has_personalized}, generate={has_generate}"
+                    print(f"  FAIL: {msg}")
+                    errors.append(f"Test 2: {msg}")
+                    failed += 1
+            else:
+                print("  FAIL: No Expand button found")
+                errors.append("Test 2: No Expand button")
+                failed += 1
+
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 2: {e}")
+            failed += 1
+
+        # ── Test 3: Results page — Video Prompts tab ───────────
+        print("\n[TEST 3] Results page — Video Prompts tab")
+        try:
+            run_id = setup_completed_run()
+            page = context.new_page()
+            page.goto(f"{FRONTEND_URL}/results/{run_id}")
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(2000)
+
+            # Click Video Prompts tab
+            prompts_tab = page.locator("text=Video Prompts")
+            if prompts_tab.is_visible():
+                prompts_tab.click()
+                page.wait_for_timeout(500)
+                page.screenshot(path=f"{SCREENSHOT_DIR}/03_video_prompts.png", full_page=True)
+
+                content = page.content()
+                has_prompt = "Video prompt for script" in content or "dramatic lighting" in content
+
+                if has_prompt:
+                    print("  PASS: Video Prompts tab shows prompts")
+                    passed += 1
+                else:
+                    print("  FAIL: Video prompt content not found")
+                    errors.append("Test 3: prompt content missing")
+                    failed += 1
+            else:
+                print("  FAIL: Video Prompts tab not found")
+                errors.append("Test 3: tab not found")
+                failed += 1
+
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 3: {e}")
+            failed += 1
+
+        # ── Test 4: Pipeline page — completed run shows all stages done ──
+        print("\n[TEST 4] Pipeline page — completed run")
+        try:
+            run_id = setup_completed_run()
+            page = context.new_page()
+            page.goto(f"{FRONTEND_URL}/pipeline/{run_id}")
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(3000)
+
+            page.screenshot(path=f"{SCREENSHOT_DIR}/04_pipeline_completed.png", full_page=True)
+
+            content = page.content()
+            has_heading = "Pipeline Progress" in content or "Pipeline" in content
+            has_stages = "Discover" in content and "Aggregate" in content and "Generate" in content
+            has_completed = content.count("completed") >= 3  # Multiple completed badges
+
+            if has_heading and has_stages:
+                print("  PASS: Pipeline page loaded with stages")
+                passed += 1
+            else:
+                msg = f"Missing: heading={has_heading}, stages={has_stages}"
+                print(f"  FAIL: {msg}")
+                errors.append(f"Test 4: {msg}")
+                failed += 1
+
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 4: {e}")
+            failed += 1
+
+        # ── Test 5: Vote page — completed run shows avatars ───
+        print("\n[TEST 5] Vote page — completed run")
+        try:
+            run_id = setup_completed_run()
+            page = context.new_page()
+            page.goto(f"{FRONTEND_URL}/vote/{run_id}")
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(3000)
+
+            page.screenshot(path=f"{SCREENSHOT_DIR}/05_vote_completed.png", full_page=True)
+
+            content = page.content()
+            has_heading = "Audience Vote" in content
+            has_leaderboard = "Leaderboard" in content
+            has_vote_count = "10" in content  # 10 votes cast
+
+            if has_heading and has_leaderboard:
+                print("  PASS: Vote page loaded with leaderboard")
+                passed += 1
+            else:
+                msg = f"Missing: heading={has_heading}, leaderboard={has_leaderboard}"
+                print(f"  FAIL: {msg}")
+                errors.append(f"Test 5: {msg}")
+                failed += 1
+
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 5: {e}")
+            failed += 1
+
+        # ── Test 6: Pipeline page — live SSE updates ──────────
+        print("\n[TEST 6] Pipeline page — live SSE streaming")
+        try:
+            run_id = setup_live_run()
+            page = context.new_page()
+
+            # Start emitting events in background
+            thread = Thread(target=emit_live_events, args=(run_id,), daemon=True)
+            thread.start()
+
+            page.goto(f"{FRONTEND_URL}/pipeline/{run_id}")
+            page.wait_for_load_state("networkidle")
+
+            # Wait for some events to arrive
+            page.wait_for_timeout(3000)
+            page.screenshot(path=f"{SCREENSHOT_DIR}/06_pipeline_live_1.png", full_page=True)
+
+            # Check for running state
+            content1 = page.content()
+            has_running = "running" in content1.lower()
+
+            # Wait for more progress
+            page.wait_for_timeout(4000)
+            page.screenshot(path=f"{SCREENSHOT_DIR}/06_pipeline_live_2.png", full_page=True)
+            content2 = page.content()
+
+            # Wait for completion
+            thread.join(timeout=15)
+            page.wait_for_timeout(3000)
+            page.screenshot(path=f"{SCREENSHOT_DIR}/06_pipeline_live_3.png", full_page=True)
+            content3 = page.content()
+
+            has_complete = "complete" in content3.lower() or "Done" in content3
+
+            if has_running or has_complete:
+                print("  PASS: Live SSE events received and rendered")
+                passed += 1
+            else:
+                print("  FAIL: No evidence of live updates")
+                errors.append("Test 6: no live updates detected")
+                failed += 1
+
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 6: {e}")
+            failed += 1
+
+        # ── Test 7: Navigation breadcrumbs ─────────────────────
+        print("\n[TEST 7] Navigation breadcrumbs")
+        try:
+            run_id = setup_completed_run()
+            page = context.new_page()
+            page.goto(f"{FRONTEND_URL}/results/{run_id}")
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(2000)
+
+            content = page.content()
+            has_home_link = 'href="/"' in content
+            has_runs_link = 'href="/runs"' in content
+            has_pipeline_link = f'href="/pipeline/{run_id}"' in content
+
+            if has_home_link and has_runs_link and has_pipeline_link:
+                print("  PASS: Breadcrumbs have correct navigation links")
+                passed += 1
+            else:
+                msg = f"Missing: home={has_home_link}, runs={has_runs_link}, pipeline={has_pipeline_link}"
+                print(f"  FAIL: {msg}")
+                errors.append(f"Test 7: {msg}")
+                failed += 1
+
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 7: {e}")
+            failed += 1
+
+        # ── Test 8: Results page — 404 for nonexistent run ────
+        print("\n[TEST 8] Results page — handles missing run")
+        try:
+            page = context.new_page()
+            page.goto(f"{FRONTEND_URL}/results/nonexistent-run-id")
+            page.wait_for_load_state("networkidle")
+            page.wait_for_timeout(2000)
+
+            page.screenshot(path=f"{SCREENSHOT_DIR}/08_results_404.png", full_page=True)
+
+            content = page.content()
+            has_error = "Failed" in content or "error" in content.lower() or "not found" in content.lower()
+
+            if has_error:
+                print("  PASS: Error state shown for missing run")
+                passed += 1
+            else:
+                print("  FAIL: No error state for missing run")
+                errors.append("Test 8: no error state")
+                failed += 1
+
+            page.close()
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            errors.append(f"Test 8: {e}")
+            failed += 1
+
+        browser.close()
+
+    # ── Summary ────────────────────────────────────────────
+    print(f"\n{'='*50}")
+    print(f"Results: {passed} passed, {failed} failed")
+    print(f"Screenshots saved to {SCREENSHOT_DIR}/")
+    if errors:
+        print("\nFailures:")
+        for e in errors:
+            print(f"  - {e}")
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = run_tests()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

Completes Sam's M4-A track — the three interactive React islands that are the visual centerpiece of the project:

- **Pipeline Visualizer** (`/pipeline/[id]`) — SSE-connected 7-stage progress view. Each stage shows pending → running (with progress bar) → completed. Framer Motion animates transitions, checkmarks, and progress fills. Auto-redirects to voting page on pipeline completion.
- **Voting Animation** (`/vote/[id]`) — 100-avatar grid (10x10) with live leaderboard. Each `vote_cast` SSE event animates the corresponding avatar and updates the ranked leaderboard. Progress counter shows votes cast / total.
- **Results Page** (`/results/[id]`) — Loads final results from API. Tabbed view (Scripts | Video Prompts). Expandable script cards show hook/body/payoff, personalized version, and video generation with status polling.

All three pages use `BaseLayout.astro` for consistent navigation. All state is derived from the existing `useSSE` hook and `api-client` module — no new API surface needed.

### Infrastructure
- Added `@astrojs/cloudflare` adapter for SSR dynamic routes (`[id]` params)
- Static pages (index) still prerender at build time
- Build passes with 0 errors, 0 warnings, 0 hints

## Test plan

- [ ] `npm run build` passes cleanly
- [ ] `/pipeline/{runId}` shows stage progression via SSE
- [ ] SSE reconnect works (disconnect → reconnect picks up from cursor)
- [ ] `/vote/{runId}` renders 100 avatars, animates on vote events
- [ ] Leaderboard reorders as votes arrive (Framer Motion layout animation)
- [ ] `/results/{runId}` loads and displays ranked scripts
- [ ] Script cards expand/collapse correctly
- [ ] Video Prompts tab shows prompts with rank and pattern
- [ ] Generate Video button triggers generation and polls for status
- [ ] Navigation breadcrumbs work across all three pages

Closes #36, #37, #38, #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)