### PR TITLE
fix: resolve 7 AWS deployment blockers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,14 +21,17 @@ FROM python:3.11-slim AS runtime
 
 WORKDIR /app
 
-# Non-root user for ECS security best practice
-RUN useradd --no-create-home --shell /bin/false appuser
+# curl for ECS container health check + non-root user
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --no-create-home --shell /bin/false appuser
 
 # Copy venv from builder
 COPY --from=builder /app/venv /app/venv
 
-# Copy application code
+# Copy application code + dataset
 COPY app/ ./app/
+COPY data/ ./data/
 
 # Use venv python
 ENV PATH="/app/venv/bin:$PATH" \

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     # Redis (db=0 for state, db=1 for Celery broker — don't mix them)
     redis_url: str = "redis://localhost:6379/0"
 
+    # CORS — comma-separated origins for production (e.g. "https://flair2.pages.dev")
+    cors_origins: str = ""
+
     # AWS
     aws_region: str = "us-east-1"
     s3_bucket: str = "flair2-pipeline"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,10 +40,11 @@ _DEV_ORIGINS = [
 ]
 
 _is_dev = settings.environment == "dev"
+_extra_origins = [o.strip() for o in settings.cors_origins.split(",") if o.strip()]
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_DEV_ORIGINS if _is_dev else [],
+    allow_origins=(_DEV_ORIGINS + _extra_origins) if _is_dev else _extra_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -269,6 +269,7 @@ module "ecs" {
   ecr_worker_image_url      = module.ecr.worker_image_url
   kimi_api_key_secret_arn   = var.kimi_api_key_secret_arn
   gemini_api_key_secret_arn = var.gemini_api_key_secret_arn
+  cors_origins              = var.cors_origins
 }
 
 module "lambda" {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -54,9 +54,14 @@ resource "aws_ecs_task_definition" "api" {
     }]
 
     environment = [
-      { name = "FLAIR2_REDIS_URL", value = var.redis_url },
+      { name = "FLAIR2_REDIS_URL", value = "${var.redis_url}/0" },
+      { name = "FLAIR2_CELERY_BROKER_URL", value = "${var.redis_url}/1" },
       { name = "FLAIR2_S3_BUCKET", value = var.s3_bucket_name },
-      { name = "FLAIR2_ENVIRONMENT", value = var.env }
+      { name = "FLAIR2_AWS_REGION", value = var.aws_region },
+      { name = "FLAIR2_DYNAMODB_RUNS_TABLE", value = "${var.project}-${var.env}-pipeline-runs" },
+      { name = "FLAIR2_DYNAMODB_PERF_TABLE", value = "${var.project}-${var.env}-video-performance" },
+      { name = "FLAIR2_ENVIRONMENT", value = var.env },
+      { name = "FLAIR2_CORS_ORIGINS", value = var.cors_origins }
     ]
 
     secrets = [
@@ -144,8 +149,12 @@ resource "aws_ecs_task_definition" "worker" {
     ]
 
     environment = [
-      { name = "FLAIR2_REDIS_URL", value = var.redis_url },
+      { name = "FLAIR2_REDIS_URL", value = "${var.redis_url}/0" },
+      { name = "FLAIR2_CELERY_BROKER_URL", value = "${var.redis_url}/1" },
       { name = "FLAIR2_S3_BUCKET", value = var.s3_bucket_name },
+      { name = "FLAIR2_AWS_REGION", value = var.aws_region },
+      { name = "FLAIR2_DYNAMODB_RUNS_TABLE", value = "${var.project}-${var.env}-pipeline-runs" },
+      { name = "FLAIR2_DYNAMODB_PERF_TABLE", value = "${var.project}-${var.env}-video-performance" },
       { name = "FLAIR2_ENVIRONMENT", value = var.env }
     ]
 

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -100,6 +100,12 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
+variable "cors_origins" {
+  description = "Comma-separated CORS origins for the API (e.g. Cloudflare Pages URL)"
+  type        = string
+  default     = ""
+}
+
 variable "kimi_api_key_secret_arn" {
   description = "Secrets Manager ARN for the Kimi (Moonshot) API key"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,3 +58,9 @@ variable "gemini_api_key_secret_arn" {
   description = "Secrets Manager ARN for the Gemini API key (video generation) — create manually before apply: aws secretsmanager create-secret --name flair2/dev/gemini-api-key"
   type        = string
 }
+
+variable "cors_origins" {
+  description = "Comma-separated CORS origins for the API (e.g. https://flair2.pages.dev)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Fixes 7 of the 9 deployment blockers identified during pre-deploy audit. The remaining 2 are operational (manual Docker push + Learner Lab cred refresh).

- **Dockerfile**: install `curl` for ECS health check + `COPY data/` so pipeline finds dataset
- **CORS**: new `FLAIR2_CORS_ORIGINS` env var for production origins (Cloudflare Pages)
- **ECS task defs**: add 5 missing env vars (`CELERY_BROKER_URL`, `AWS_REGION`, `DYNAMODB_RUNS_TABLE`, `DYNAMODB_PERF_TABLE`, `CORS_ORIGINS`)
- **Redis URL**: append `/0` (state) and `/1` (broker) to ElastiCache URL

## Test plan

- [ ] `terraform validate` passes
- [ ] `terraform fmt -check -recursive` passes
- [ ] Backend pytest passes (126/127 — 1 pre-existing flaky scale test)
- [ ] `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)