### PR TITLE
fix: bootstrap job working-directory override

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -67,6 +67,7 @@ jobs:
 
     steps:
       - name: Create S3 state bucket (idempotent)
+        working-directory: .
         run: |
           if aws s3api head-bucket --bucket flair2-terraform-state 2>/dev/null; then
             echo "Bucket already exists — skipping creation"


### PR DESCRIPTION
The bootstrap job fails with `No such file or directory` because the global `defaults.run.working-directory: terraform` applies to it, but the bootstrap job has no `actions/checkout` step and only runs `aws s3api` commands.

Fix: add `working-directory: .` to the bootstrap step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)