### PR TITLE
chore: Kimi-only deployment, remove Gemini secret requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl
+
 # Python
 __pycache__/
 *.py[cod]

--- a/terraform/environments/dev.tfvars
+++ b/terraform/environments/dev.tfvars
@@ -8,9 +8,7 @@ public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
 private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
 availability_zones   = ["us-west-2a", "us-west-2b"]
 
-# Create secrets manually before apply:
+# Create the Kimi API key secret manually before apply:
 #   aws secretsmanager create-secret --name flair2/dev/kimi-api-key --secret-string "YOUR_KEY"
-#   aws secretsmanager create-secret --name flair2/dev/gemini-api-key --secret-string "YOUR_KEY"
-# Then paste the ARNs returned by the above commands here.
-kimi_api_key_secret_arn   = "REPLACE_WITH_ARN_AFTER_CREATING_SECRET"
-gemini_api_key_secret_arn = "REPLACE_WITH_ARN_AFTER_CREATING_SECRET"
+# Then paste the ARN returned by the command here.
+kimi_api_key_secret_arn = "REPLACE_WITH_ARN_AFTER_CREATING_SECRET"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -253,23 +253,22 @@ module "alb" {
 }
 
 module "ecs" {
-  source                    = "./modules/ecs"
-  project                   = var.project
-  env                       = var.env
-  aws_region                = var.aws_region
-  vpc_id                    = aws_vpc.main.id
-  private_subnet_ids        = aws_subnet.private[*].id
-  security_group_id         = aws_security_group.ecs.id
-  execution_role_arn        = module.iam.ecs_execution_role_arn
-  task_role_arn             = module.iam.ecs_task_role_arn
-  alb_target_group_arn      = module.alb.target_group_arn
-  redis_url                 = module.elasticache.redis_url
-  s3_bucket_name            = module.s3.bucket_name
-  ecr_api_image_url         = module.ecr.api_image_url
-  ecr_worker_image_url      = module.ecr.worker_image_url
-  kimi_api_key_secret_arn   = var.kimi_api_key_secret_arn
-  gemini_api_key_secret_arn = var.gemini_api_key_secret_arn
-  cors_origins              = var.cors_origins
+  source                  = "./modules/ecs"
+  project                 = var.project
+  env                     = var.env
+  aws_region              = var.aws_region
+  vpc_id                  = aws_vpc.main.id
+  private_subnet_ids      = aws_subnet.private[*].id
+  security_group_id       = aws_security_group.ecs.id
+  execution_role_arn      = module.iam.ecs_execution_role_arn
+  task_role_arn           = module.iam.ecs_task_role_arn
+  alb_target_group_arn    = module.alb.target_group_arn
+  redis_url               = module.elasticache.redis_url
+  s3_bucket_name          = module.s3.bucket_name
+  ecr_api_image_url       = module.ecr.api_image_url
+  ecr_worker_image_url    = module.ecr.worker_image_url
+  kimi_api_key_secret_arn = var.kimi_api_key_secret_arn
+  cors_origins            = var.cors_origins
 }
 
 module "lambda" {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -65,8 +65,7 @@ resource "aws_ecs_task_definition" "api" {
     ]
 
     secrets = [
-      { name = "FLAIR2_KIMI_API_KEY", valueFrom = var.kimi_api_key_secret_arn },
-      { name = "FLAIR2_GEMINI_API_KEY", valueFrom = var.gemini_api_key_secret_arn }
+      { name = "FLAIR2_KIMI_API_KEY", valueFrom = var.kimi_api_key_secret_arn }
     ]
 
     logConfiguration = {
@@ -159,8 +158,7 @@ resource "aws_ecs_task_definition" "worker" {
     ]
 
     secrets = [
-      { name = "FLAIR2_KIMI_API_KEY", valueFrom = var.kimi_api_key_secret_arn },
-      { name = "FLAIR2_GEMINI_API_KEY", valueFrom = var.gemini_api_key_secret_arn }
+      { name = "FLAIR2_KIMI_API_KEY", valueFrom = var.kimi_api_key_secret_arn }
     ]
 
     logConfiguration = {

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -110,8 +110,3 @@ variable "kimi_api_key_secret_arn" {
   description = "Secrets Manager ARN for the Kimi (Moonshot) API key"
   type        = string
 }
-
-variable "gemini_api_key_secret_arn" {
-  description = "Secrets Manager ARN for the Gemini API key (video generation only)"
-  type        = string
-}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -40,8 +40,7 @@ resource "aws_iam_role_policy" "ecs_execution_secrets" {
       Effect = "Allow"
       Action = "secretsmanager:GetSecretValue"
       Resource = [
-        "arn:aws:secretsmanager:*:*:secret:${var.project}/${var.env}/kimi-api-key*",
-        "arn:aws:secretsmanager:*:*:secret:${var.project}/${var.env}/gemini-api-key*"
+        "arn:aws:secretsmanager:*:*:secret:${var.project}/${var.env}/kimi-api-key*"
       ]
     }]
   })

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,10 +54,6 @@ variable "kimi_api_key_secret_arn" {
   type        = string
 }
 
-variable "gemini_api_key_secret_arn" {
-  description = "Secrets Manager ARN for the Gemini API key (video generation) — create manually before apply: aws secretsmanager create-secret --name flair2/dev/gemini-api-key"
-  type        = string
-}
 
 variable "cors_origins" {
   description = "Comma-separated CORS origins for the API (e.g. https://flair2.pages.dev)"


### PR DESCRIPTION
## Summary

Remove Gemini API key as a deployment requirement. All reasoning stages (S1-S6) use Kimi. Gemini is only for video generation (Lambda, not wired yet).

- Remove `gemini_api_key_secret_arn` from ECS task defs, root module, variables, tfvars, IAM policy
- Add `.terraform/` and state files to `.gitignore`
- Only one secret needed before `terraform apply`:
  ```
  aws secretsmanager create-secret --name flair2/dev/kimi-api-key --secret-string "YOUR_KEY"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)