### PR TITLE
chore: wire Kimi API key secret ARN into dev.tfvars

### DIFF
--- a/terraform/environments/dev.tfvars
+++ b/terraform/environments/dev.tfvars
@@ -11,4 +11,4 @@ availability_zones   = ["us-west-2a", "us-west-2b"]
 # Create the Kimi API key secret manually before apply:
 #   aws secretsmanager create-secret --name flair2/dev/kimi-api-key --secret-string "YOUR_KEY"
 # Then paste the ARN returned by the command here.
-kimi_api_key_secret_arn = "REPLACE_WITH_ARN_AFTER_CREATING_SECRET"
+kimi_api_key_secret_arn = "arn:aws:secretsmanager:us-west-2:966294739208:secret:flair2/dev/kimi-api-key-JYvv9k"


### PR DESCRIPTION
## Summary

Fills in the `kimi_api_key_secret_arn` in `terraform/environments/dev.tfvars` with the ARN of the secret created in AWS Secrets Manager.

Secret: `flair2/dev/kimi-api-key` (us-west-2, account 966294739208)

After this merges, `terraform apply -var-file=environments/dev.tfvars` can run without placeholder values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)