### PR TITLE
fix: terraform plan/apply missing -var-file

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -107,7 +107,7 @@ jobs:
         run: terraform init -backend-config="key=env/dev/terraform.tfstate"
 
       - name: Plan
-        run: terraform plan -var="env=dev" -no-color
+        run: terraform plan -var-file=environments/dev.tfvars -no-color
         continue-on-error: false
 
   # ── Apply (manual only, needs AWS creds) ────────────────────────────────────
@@ -136,4 +136,4 @@ jobs:
         run: terraform init -backend-config="key=env/dev/terraform.tfstate"
 
       - name: Apply
-        run: terraform apply -var="env=dev" -auto-approve -no-color
+        run: terraform apply -var-file=environments/dev.tfvars -auto-approve -no-color


### PR DESCRIPTION
Plan and apply used `-var="env=dev"` which doesn't load the tfvars file. Terraform hangs waiting for interactive input for required variables (`kimi_api_key_secret_arn`, `vpc_cidr`, etc.) — which never comes in CI.

This is why the Plan job hung for 17+ minutes with no output.

Fix: `-var-file=environments/dev.tfvars`

🤖 Generated with [Claude Code](https://claude.com/claude-code)