### PR TITLE
fix: remove COPY data/ from Dockerfile — excluded by .dockerignore

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,9 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 # Copy venv from builder
 COPY --from=builder /app/venv /app/venv
 
-# Copy application code + dataset
+# Copy application code
 COPY app/ ./app/
-COPY data/ ./data/
 
 # Use venv python
 ENV PATH="/app/venv/bin:$PATH" \


### PR DESCRIPTION
## 问题

Docker build 报错 `/data: not found`，连续两次失败。

根本原因是**两边冲突**：
- `.dockerignore` 排除了 `data/`，注释写着 "not needed in image"  
- `Dockerfile` 却有 `COPY data/ ./data/`

因为 `.dockerignore` 把 `data/` 从 build context 里排除了，所以 Docker 找不到这个目录，报错。

## 修复

删掉 `Dockerfile` 里的 `COPY data/ ./data/` 这行，和 `.dockerignore` 保持一致。数据文件不需要打进镜像里。

## 测试

- [ ] CD workflow Docker build 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)