### PR TITLE
test: Locust load test — M5-4 API concurrent load (closes #89)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,9 @@ data = [
     "huggingface-hub>=0.21",
 ]
 
+[tool.setuptools.packages.find]
+include = ["app*"]
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100

--- a/backend/tests/load/locustfile.py
+++ b/backend/tests/load/locustfile.py
@@ -1,0 +1,98 @@
+"""Locust load test — M5-4: API concurrent load test.
+
+Runs K concurrent virtual users against the deployed ALB.
+Each user starts pipeline runs, lists runs, and checks providers.
+
+Usage:
+    # Install locust first:
+    pip install locust
+
+    # Against deployed AWS:
+    locust -f tests/load/locustfile.py \
+        --host http://<ALB_DNS_NAME> \
+        --users 10 --spawn-rate 2 --run-time 60s \
+        --headless --csv=../../docs/locust-results
+
+    # Multiple K values (run sequentially):
+    for K in 1 5 10 20; do
+        locust -f tests/load/locustfile.py \
+            --host http://<ALB_DNS_NAME> \
+            --users $K --spawn-rate $K --run-time 60s \
+            --headless --csv=../../docs/locust-k${K}
+    done
+
+Issue: https://github.com/yangyang-how/flair2/issues/89
+"""
+
+import uuid
+
+from locust import HttpUser, between, task
+
+
+# Sample creator profile — minimal but valid
+SAMPLE_PROFILE = {
+    "tone": "casual",
+    "vocabulary": ["insane", "literally"],
+    "catchphrases": ["here's the thing"],
+    "topics_to_avoid": ["politics"],
+    "niche": "content creation tips",
+    "audience_description": "18-25 aspiring creators",
+    "content_themes": ["growth hacks"],
+    "example_hooks": ["Stop scrolling"],
+    "recent_topics": ["algorithm changes"],
+}
+
+
+class PipelineUser(HttpUser):
+    """Simulates a user interacting with the Flair2 API.
+
+    Each virtual user gets a unique session_id so run history
+    is properly scoped and doesn't collide across users.
+    """
+
+    # Wait 1-3s between tasks to simulate realistic user behavior
+    wait_time = between(1, 3)
+
+    def on_start(self):
+        """Called once per user when they start. Set up session."""
+        self.session_id = str(uuid.uuid4())
+
+    @task(1)
+    def get_providers(self):
+        """GET /api/providers — lightweight read, should be fast."""
+        self.client.get("/api/providers", name="/api/providers")
+
+    @task(2)
+    def list_runs(self):
+        """GET /api/runs — list runs for this session."""
+        self.client.get(
+            f"/api/runs?session_id={self.session_id}",
+            name="/api/runs",
+        )
+
+    @task(3)
+    def start_pipeline(self):
+        """POST /api/pipeline/start — the heavy operation.
+
+        Uses small counts to avoid overwhelming the LLM provider
+        during load tests. The goal is to test API/infra throughput,
+        not pipeline completion.
+        """
+        payload = {
+            "creator_profile": SAMPLE_PROFILE,
+            "reasoning_model": "kimi",
+            "num_videos": 2,
+            "num_scripts": 2,
+            "num_personas": 2,
+            "top_n": 1,
+        }
+        self.client.post(
+            f"/api/pipeline/start?session_id={self.session_id}",
+            json=payload,
+            name="/api/pipeline/start",
+        )
+
+    @task(1)
+    def health_check(self):
+        """GET /api/health — baseline latency measurement."""
+        self.client.get("/api/health", name="/api/health")

--- a/backend/tests/load/locustfile.py
+++ b/backend/tests/load/locustfile.py
@@ -28,7 +28,6 @@ import uuid
 
 from locust import HttpUser, between, task
 
-
 # Sample creator profile — minimal but valid
 SAMPLE_PROFILE = {
     "tone": "casual",

--- a/backend/tests/load/run_all_k.sh
+++ b/backend/tests/load/run_all_k.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run Locust load test at K=1, 5, 10, 20 and save results.
+#
+# Usage:
+#   export ALB_URL=http://<your-alb-dns-name>
+#   bash tests/load/run_all_k.sh
+
+set -euo pipefail
+
+if [ -z "${ALB_URL:-}" ]; then
+    echo "ERROR: Set ALB_URL first:"
+    echo "  export ALB_URL=http://\$(aws elbv2 describe-load-balancers --region us-west-2 --query 'LoadBalancers[?LoadBalancerName==\`flair2-dev-alb\`].DNSName' --output text)"
+    exit 1
+fi
+
+RESULTS_DIR="$(cd "$(dirname "$0")/../../docs/load-test-results" && pwd)"
+mkdir -p "$RESULTS_DIR"
+
+echo "=== Locust Load Test ==="
+echo "Target: $ALB_URL"
+echo "Results: $RESULTS_DIR"
+echo ""
+
+for K in 1 5 10 20; do
+    echo "--- K=$K users, 60s run ---"
+    locust -f "$(dirname "$0")/locustfile.py" \
+        --host "$ALB_URL" \
+        --users "$K" \
+        --spawn-rate "$K" \
+        --run-time 60s \
+        --headless \
+        --csv="$RESULTS_DIR/k${K}" \
+        2>&1 | tail -5
+    echo ""
+done
+
+echo "=== Done. Results in $RESULTS_DIR ==="
+ls -la "$RESULTS_DIR"


### PR DESCRIPTION
## Summary

Adds Locust load test for K=1,5,10,20 concurrent users against the deployed ALB.

**Files:**
- `tests/load/locustfile.py` — 4 weighted tasks (pipeline start, list runs, providers, health)
- `tests/load/run_all_k.sh` — runs all K values sequentially, saves CSV results

**Run it:**
```bash
pip install locust
export ALB_URL=http://<your-alb-dns>
bash tests/load/run_all_k.sh
```

**Acceptance criteria from #89:**
- [x] Locust task file written and checked in
- [ ] Run against deployed AWS ALB
- [ ] p95 < 2s at K=10
- [ ] Error rate < 1% at K=10
- [ ] Results in write-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)