### PR TITLE
feat: frontend CD — S3 + CloudFront deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - "backend/**"
-  # Manual trigger — useful when infra changed but code didn't
+      - "frontend/**"
   workflow_dispatch:
 
 env:
@@ -16,10 +16,13 @@ env:
   ECS_CLUSTER: flair2-dev-cluster
   ECS_API_SERVICE: flair2-dev-api
   ECS_WORKER_SERVICE: flair2-dev-worker
+  FRONTEND_S3_BUCKET: flair2-dev-frontend
+  CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
 
 jobs:
-  deploy:
-    name: Build + Push + Deploy
+  # ── Backend ────────────────────────────────────────────────────────────────
+  deploy-backend:
+    name: Backend — Docker → ECR → ECS
     runs-on: ubuntu-latest
 
     steps:
@@ -36,7 +39,6 @@ jobs:
       - name: Login to ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      # Build once — same image for API and worker (worker overrides CMD in task def)
       - name: Build Docker image
         run: |
           docker build \
@@ -53,7 +55,6 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_WORKER_REPO:${{ github.sha }}
           docker push $ECR_REGISTRY/$ECR_WORKER_REPO:latest
 
-      # Force ECS to pull the new :latest image and restart containers
       - name: Deploy to ECS
         run: |
           aws ecs update-service \
@@ -84,4 +85,53 @@ jobs:
             --services $ECS_WORKER_SERVICE \
             --region $AWS_REGION
 
-          echo "Deploy complete."
+          echo "Backend deploy complete."
+
+  # ── Frontend ───────────────────────────────────────────────────────────────
+  deploy-frontend:
+    name: Frontend — Build → S3 → CloudFront
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: cd frontend && npm ci
+
+      - name: Build
+        run: cd frontend && npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload to S3
+        run: |
+          aws s3 sync frontend/dist/ s3://$FRONTEND_S3_BUCKET/ \
+            --delete \
+            --region $AWS_REGION
+
+      - name: Invalidate CloudFront cache
+        if: env.CLOUDFRONT_DISTRIBUTION_ID != ''
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
+            --paths "/*" \
+            --no-cli-pager
+
+          echo "Frontend deploy complete."
+          echo "URL: https://$(aws cloudfront get-distribution \
+            --id $CLOUDFRONT_DISTRIBUTION_ID \
+            --query 'Distribution.DomainName' \
+            --output text)"


### PR DESCRIPTION
## Summary

Add frontend deployment to the CD workflow. Backend and frontend deploy in parallel.

**Frontend job:** `npm build` → `aws s3 sync` → `cloudfront create-invalidation`

**After first `terraform apply`:** set the GitHub variable `CLOUDFRONT_DISTRIBUTION_ID` (Settings → Variables → Actions) so the invalidation step knows which distribution to clear.

**Trigger:** push to `main` changing `backend/` or `frontend/`, or manual `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)