### PR TITLE
fix: S3 website hosting instead of CloudFront

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ env:
   ECS_API_SERVICE: flair2-dev-api
   ECS_WORKER_SERVICE: flair2-dev-worker
   FRONTEND_S3_BUCKET: flair2-dev-frontend
-  CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
 
 jobs:
   # ── Backend ────────────────────────────────────────────────────────────────
@@ -89,7 +88,7 @@ jobs:
 
   # ── Frontend ───────────────────────────────────────────────────────────────
   deploy-frontend:
-    name: Frontend — Build → S3 → CloudFront
+    name: Frontend — Build → S3
     runs-on: ubuntu-latest
 
     steps:
@@ -105,9 +104,6 @@ jobs:
       - name: Install dependencies
         run: cd frontend && npm ci
 
-      - name: Build
-        run: cd frontend && npm run build
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -116,22 +112,24 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Get ALB URL
+        id: alb
+        run: |
+          ALB_DNS=$(aws elbv2 describe-load-balancers --region $AWS_REGION \
+            --query 'LoadBalancers[?LoadBalancerName==`flair2-dev-alb`].DNSName' \
+            --output text)
+          echo "url=http://${ALB_DNS}" >> $GITHUB_OUTPUT
+
+      - name: Build frontend
+        run: cd frontend && npm run build
+        env:
+          PUBLIC_API_URL: ${{ steps.alb.outputs.url }}
+
       - name: Upload to S3
         run: |
           aws s3 sync frontend/dist/ s3://$FRONTEND_S3_BUCKET/ \
             --delete \
             --region $AWS_REGION
 
-      - name: Invalidate CloudFront cache
-        if: env.CLOUDFRONT_DISTRIBUTION_ID != ''
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
-            --paths "/*" \
-            --no-cli-pager
-
-          echo "Frontend deploy complete."
-          echo "URL: https://$(aws cloudfront get-distribution \
-            --id $CLOUDFRONT_DISTRIBUTION_ID \
-            --query 'Distribution.DomainName' \
-            --output text)"
+      - name: Print frontend URL
+        run: echo "Frontend deployed to http://$FRONTEND_S3_BUCKET.s3-website-$AWS_REGION.amazonaws.com"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -268,14 +268,13 @@ module "ecs" {
   ecr_api_image_url       = module.ecr.api_image_url
   ecr_worker_image_url    = module.ecr.worker_image_url
   kimi_api_key_secret_arn = var.kimi_api_key_secret_arn
-  cors_origins            = var.cors_origins
+  cors_origins            = module.frontend.website_url
 }
 
 module "frontend" {
-  source     = "./modules/frontend"
-  project    = var.project
-  env        = var.env
-  api_origin = module.alb.dns_name
+  source  = "./modules/frontend"
+  project = var.project
+  env     = var.env
 }
 
 module "lambda" {

--- a/terraform/modules/frontend/main.tf
+++ b/terraform/modules/frontend/main.tf
@@ -3,7 +3,7 @@ locals {
   bucket_name = "${local.prefix}-frontend"
 }
 
-# ── S3 Bucket for static files ─────────────────────────────────────────────
+# ── S3 Bucket ──────────────────────────────────────────────────────────────
 
 resource "aws_s3_bucket" "frontend" {
   bucket = local.bucket_name
@@ -11,142 +11,44 @@ resource "aws_s3_bucket" "frontend" {
   tags = { Name = local.bucket_name }
 }
 
+# ── Static website hosting ─────────────────────────────────────────────────
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+# ── Allow public read (required for S3 website hosting) ────────────────────
+
 resource "aws_s3_bucket_public_access_block" "frontend" {
   bucket = aws_s3_bucket.frontend.id
 
-  # CloudFront accesses via OAC, not public access
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
-
-# ── CloudFront Origin Access Control ───────────────────────────────────────
-
-resource "aws_cloudfront_origin_access_control" "frontend" {
-  name                              = "${local.prefix}-frontend-oac"
-  origin_access_control_origin_type = "s3"
-  signing_behavior                  = "always"
-  signing_protocol                  = "sigv4"
-}
-
-# ── CloudFront Distribution ───────────────────────────────────────────────
-
-resource "aws_cloudfront_distribution" "frontend" {
-  enabled             = true
-  default_root_object = "index.html"
-  comment             = "${local.prefix} frontend"
-
-  # S3 origin for static files
-  origin {
-    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
-    origin_id                = "s3-frontend"
-    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
-  }
-
-  # API origin — proxy /api/* to ALB
-  origin {
-    domain_name = var.api_origin
-    origin_id   = "api-backend"
-
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = "http-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
-    }
-  }
-
-  # /api/* → ALB backend (no CORS needed — same origin!)
-  ordered_cache_behavior {
-    path_pattern     = "/api/*"
-    target_origin_id = "api-backend"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-    cached_methods   = ["GET", "HEAD"]
-
-    forwarded_values {
-      query_string = true
-      headers      = ["Origin", "Authorization", "Content-Type", "Last-Event-ID"]
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    viewer_protocol_policy = "allow-all"
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
-  }
-
-  # Everything else → S3 static files
-  default_cache_behavior {
-    target_origin_id = "s3-frontend"
-    allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = ["GET", "HEAD"]
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    viewer_protocol_policy = "allow-all"
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 86400
-  }
-
-  # SPA fallback — return index.html for client-side routes
-  custom_error_response {
-    error_code         = 403
-    response_code      = 200
-    response_page_path = "/index.html"
-  }
-
-  custom_error_response {
-    error_code         = 404
-    response_code      = 200
-    response_page_path = "/index.html"
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-
-  viewer_certificate {
-    cloudfront_default_certificate = true
-  }
-
-  tags = { Name = "${local.prefix}-frontend-cdn" }
-}
-
-# ── S3 Bucket Policy — allow CloudFront OAC ───────────────────────────────
-
-data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket_policy" "frontend" {
   bucket = aws_s3_bucket.frontend.id
 
+  depends_on = [aws_s3_bucket_public_access_block.frontend]
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Sid    = "AllowCloudFrontOAC"
-      Effect = "Allow"
-      Principal = {
-        Service = "cloudfront.amazonaws.com"
-      }
-      Action   = "s3:GetObject"
-      Resource = "${aws_s3_bucket.frontend.arn}/*"
-      Condition = {
-        StringEquals = {
-          "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
-        }
-      }
+      Sid       = "PublicRead"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.frontend.arn}/*"
     }]
   })
 }

--- a/terraform/modules/frontend/outputs.tf
+++ b/terraform/modules/frontend/outputs.tf
@@ -1,11 +1,6 @@
-output "cloudfront_domain_name" {
-  description = "CloudFront distribution domain name — this is the frontend URL"
-  value       = aws_cloudfront_distribution.frontend.domain_name
-}
-
-output "cloudfront_distribution_id" {
-  description = "CloudFront distribution ID — needed for cache invalidation after deploys"
-  value       = aws_cloudfront_distribution.frontend.id
+output "website_url" {
+  description = "S3 website URL — this is the frontend"
+  value       = "http://${aws_s3_bucket_website_configuration.frontend.website_endpoint}"
 }
 
 output "s3_bucket_name" {

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -7,8 +7,3 @@ variable "env" {
   description = "Deployment environment"
   type        = string
 }
-
-variable "api_origin" {
-  description = "Backend ALB DNS name (for CORS and API proxy)"
-  type        = string
-}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -25,18 +25,13 @@ output "alb_dns_name" {
 # ── Frontend ─────────────────────────────────────────────────────────────────
 
 output "frontend_url" {
-  description = "CloudFront URL — this is the frontend"
-  value       = "https://${module.frontend.cloudfront_domain_name}"
+  description = "S3 website URL — this is the frontend"
+  value       = module.frontend.website_url
 }
 
 output "frontend_s3_bucket" {
   description = "S3 bucket for frontend static files"
   value       = module.frontend.s3_bucket_name
-}
-
-output "cloudfront_distribution_id" {
-  description = "CloudFront distribution ID — for cache invalidation"
-  value       = module.frontend.cloudfront_distribution_id
 }
 
 # ── ElastiCache ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
CloudFront is blocked on Learner Lab. Replace with S3 static website hosting.

After merge: `terraform apply` → `Deploy workflow` (manual trigger) → frontend is live.

CORS is auto-configured — Terraform passes the S3 website URL to the ECS task def as `FLAIR2_CORS_ORIGINS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)