### PR TITLE
fix: correct ECS container name in integration-tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,7 +91,7 @@ jobs:
             --network-configuration "awsvpcConfiguration={subnets=[${{ steps.network.outputs.subnets }}],securityGroups=[${{ steps.network.outputs.security_groups }}],assignPublicIp=DISABLED}" \
             --overrides "{
               \"containerOverrides\": [{
-                \"name\": \"app\",
+                \"name\": \"worker\",
                 \"command\": [\"python\", \"-m\", \"pytest\",
                               \"tests/experiments/test_elasticache_integration.py\",
                               \"-v\", \"--tb=short\", \"--no-header\"],


### PR DESCRIPTION
## Problem

Integration Tests workflow has been failing with:

```
InvalidParameterException: Override for container named app
is not a container in the TaskDefinition.
```

The `containerOverrides` in `aws ecs run-task` specified `"name": "app"`, but the worker task definition (defined in `terraform/modules/ecs/main.tf`) names the container `"worker"`.

## Fix

One-line change: `"app"` → `"worker"` in the ECS container override.

## Test plan
- [ ] Merge → Integration Tests workflow re-runs automatically after next deploy
- [ ] Workflow should reach the "Wait for test task to finish" step instead of failing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)