### PR TITLE
fix: use pytest_asyncio.fixture for async Redis fixture

### DIFF
--- a/backend/tests/experiments/test_elasticache_integration.py
+++ b/backend/tests/experiments/test_elasticache_integration.py
@@ -36,6 +36,7 @@ import time
 import uuid
 
 import pytest
+import pytest_asyncio
 import redis.asyncio as aioredis
 
 # ── Skip entire module when no real Redis is available ───────────────────────
@@ -59,7 +60,7 @@ _MEMORY_WARN_MB: float = 50.0     # warn (but don't fail) if usage exceeds this
 
 # ── Shared fixture ───────────────────────────────────────────────────────────
 
-@pytest.fixture()
+@pytest_asyncio.fixture()
 async def redis() -> aioredis.Redis:
     """Return an authenticated Redis connection and flush the test namespace on teardown."""
     assert ELASTICACHE_URL is not None  # already guarded by pytestmark


### PR DESCRIPTION
## Problem

All 6 ElastiCache integration tests were failing at setup with:

```
PytestRemovedIn9Warning: 'test_setnx_latency' requested an async fixture 'redis',
with no plugin or hook that handled it.
======================== 2 warnings, 6 errors in 0.19s =========================
```

Root cause: pytest-asyncio >=0.23 requires async fixtures to use `@pytest_asyncio.fixture()` instead of `@pytest.fixture()`. The old decorator silently stopped working for async fixtures.

## Fix

```python
# Before
@pytest.fixture()
async def redis() -> aioredis.Redis:

# After
@pytest_asyncio.fixture()
async def redis() -> aioredis.Redis:
```

Two-line change: add `import pytest_asyncio` and change the decorator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)