### PR TITLE
feat: V1-quality ResultsView + VotingAnimation for text-based output

### DIFF
--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -1,10 +1,12 @@
 /**
- * Results View — displays pipeline results with video generation.
+ * Results View — V2 campaign output display.
  *
- * Loads final results from the API, shows ranked scripts in tabs,
- * and provides video generation with polling.
+ * V2 output is TEXT, not images: video scripts (hook/body/payoff),
+ * personalized versions in the creator's voice, and video prompts
+ * for AI video generation models.
  *
- * Issue: https://github.com/yangyang-how/flair2/issues/38
+ * Design: V1 aesthetic (Bebas Neue + Cormorant Garamond + DM Sans)
+ * adapted for text-first output.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -32,36 +34,27 @@ export default function ResultsView({ runId }: ResultsViewProps) {
 
   useEffect(() => {
     let cancelled = false;
-
     async function load() {
       try {
         const data = await getPipelineResults(runId);
-        if (!cancelled) {
-          setResults(data);
-          setLoading(false);
-        }
+        if (!cancelled) { setResults(data); setLoading(false); }
       } catch (err) {
         if (!cancelled) {
-          setError(
-            err instanceof Error ? err.message : "Failed to load results",
-          );
+          setError(err instanceof Error ? err.message : "Failed to load results");
           setLoading(false);
         }
       }
     }
-
     load();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [runId]);
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 gap-3">
+      <div className="flex flex-col items-center justify-center py-20 gap-4">
         <Spinner size="lg" />
-        <p className="text-sm text-[var(--color-text-muted)]">
-          Loading results...
+        <p className="font-body text-lg text-[var(--color-text-muted)]">
+          Loading your campaign...
         </p>
       </div>
     );
@@ -69,14 +62,14 @@ export default function ResultsView({ runId }: ResultsViewProps) {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/5 p-6 text-center">
-        <p className="font-medium text-[var(--color-error)]">
-          Failed to load results
+      <div className="rounded-[10px] border border-[var(--eval-c)] bg-[var(--eval-d)]/30 p-8 text-center">
+        <p className="font-display text-xl tracking-[0.08em] text-[var(--eval-b)]">
+          Failed to Load
         </p>
-        <p className="mt-1 text-sm text-[var(--color-text-muted)]">{error}</p>
+        <p className="mt-2 font-body text-base text-[var(--color-text-muted)]">{error}</p>
         <a
           href={`/pipeline/${runId}`}
-          className="mt-3 inline-block text-sm text-[var(--color-accent)] hover:underline"
+          className="mt-4 inline-block font-ui text-[11px] uppercase tracking-[0.1em] text-[var(--stud-b)] hover:underline"
         >
           Check pipeline status
         </a>
@@ -87,39 +80,45 @@ export default function ResultsView({ runId }: ResultsViewProps) {
   if (!results || results.results.length === 0) {
     return (
       <div className="py-20 text-center">
-        <p className="text-[var(--color-text-muted)]">
+        <p className="font-body text-lg text-[var(--color-text-muted)]">
           No results found for this run.
         </p>
       </div>
     );
   }
 
+  // Winner script for the hero section
+  const winner = results.results[0];
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h2 className="text-xl font-semibold">Campaign Results</h2>
-        <p className="text-sm text-[var(--color-text-muted)]">
-          Top {results.results.length} scripts, ranked by audience vote
+    <div className="space-y-8">
+      {/* Hero — winning script */}
+      <div className="text-center">
+        <p className="font-ui text-[10px] uppercase tracking-[0.18em] text-[var(--color-text-light)]">
+          Top ranked by {results.results.length > 1 ? "audience vote" : "evaluation"}
         </p>
+        <h2 className="font-display text-[clamp(28px,5vw,48px)] tracking-[0.06em] mt-2">
+          Campaign Results
+        </h2>
+        {winner && (
+          <p className="font-body mx-auto mt-3 max-w-lg text-lg text-[var(--color-text-muted)]">
+            &ldquo;{winner.original_script.hook}&rdquo;
+          </p>
+        )}
       </div>
 
-      {/* Tabs: Scripts | Video Prompts */}
+      {/* Tabs */}
       <Tabs
         tabs={[
           {
             id: "scripts",
             label: `Scripts (${results.results.length})`,
-            content: (
-              <ScriptList results={results.results} runId={runId} />
-            ),
+            content: <ScriptList results={results.results} runId={runId} />,
           },
           {
             id: "prompts",
             label: "Video Prompts",
-            content: (
-              <VideoPromptList results={results.results} />
-            ),
+            content: <VideoPromptList results={results.results} />,
           },
         ]}
       />
@@ -129,15 +128,9 @@ export default function ResultsView({ runId }: ResultsViewProps) {
 
 // ── Script List ───────────────────────────────────────────
 
-function ScriptList({
-  results,
-  runId,
-}: {
-  results: FinalResult[];
-  runId: string;
-}) {
+function ScriptList({ results, runId }: { results: FinalResult[]; runId: string }) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       {results.map((result) => (
         <ScriptCard key={result.script_id} result={result} runId={runId} />
       ))}
@@ -147,110 +140,101 @@ function ScriptList({
 
 // ── Script Card ───────────────────────────────────────────
 
-function ScriptCard({
-  result,
-  runId,
-}: {
-  result: FinalResult;
-  runId: string;
-}) {
+function ScriptCard({ result, runId }: { result: FinalResult; runId: string }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <Card>
-      <div className="space-y-3">
+    <Card padding="lg">
+      <div className="space-y-4">
         {/* Rank header */}
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-4">
             <span
-              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold ${
-                result.rank === 1
-                  ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)]"
-                  : "bg-[var(--color-border)] text-[var(--color-text-muted)]"
-              }`}
+              className="flex h-10 w-10 items-center justify-center rounded-full font-display text-lg"
+              style={{
+                backgroundColor: result.rank === 1 ? "var(--eval-d)" : "rgba(14,12,20,0.04)",
+                color: result.rank === 1 ? "var(--eval-b)" : "var(--color-text-muted)",
+              }}
             >
               {result.rank}
             </span>
             <div>
-              <span className="font-mono text-xs text-[var(--color-text-muted)]">
-                {result.script_id.slice(0, 12)}
+              <span className="font-ui text-[10px] uppercase tracking-[0.1em] text-[var(--color-text-light)]">
+                {result.original_script.pattern_used}
               </span>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-[var(--color-text-muted)]">
-                  Pattern: {result.original_script.pattern_used}
+              <div className="flex items-center gap-3 mt-0.5">
+                <span className="font-ui text-[10px] text-[var(--eval-a)]">
+                  {result.vote_score.toFixed(1)} votes
                 </span>
-                <span className="text-xs text-[var(--color-text-muted)]">
-                  Score: {result.vote_score.toFixed(1)}
+                <span className="font-ui text-[10px] text-[var(--color-text-light)]">
+                  ~{result.original_script.estimated_duration.toFixed(0)}s
                 </span>
               </div>
             </div>
           </div>
           <button
             onClick={() => setExpanded((s) => !s)}
-            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            className="font-ui text-[10px] uppercase tracking-[0.1em] text-[var(--color-text-muted)] hover:text-[var(--color-ink)] transition-colors"
           >
             {expanded ? "Collapse" : "Expand"}
           </button>
         </div>
 
-        {/* Hook (always visible) */}
+        {/* Hook — always visible, hero treatment */}
         <div>
-          <p className="text-xs font-semibold uppercase text-[var(--color-accent)]">
+          <p className="font-ui text-[9px] uppercase tracking-[0.14em] text-[var(--disc-b)]">
             Hook
           </p>
-          <p className="mt-1 text-sm leading-relaxed">
+          <p className="font-body mt-1 text-xl leading-relaxed">
             {result.original_script.hook}
           </p>
         </div>
 
-        {/* Expanded content */}
+        {/* Expanded: Body + Payoff + Personalized + Video Prompt */}
         <AnimatePresence>
           {expanded && (
             <motion.div
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
               exit={{ opacity: 0, height: 0 }}
-              className="space-y-3 overflow-hidden"
+              className="space-y-5 overflow-hidden"
             >
               {/* Body */}
               <div>
-                <p className="text-xs font-semibold uppercase text-[var(--color-accent)]">
+                <p className="font-ui text-[9px] uppercase tracking-[0.14em] text-[var(--stud-b)]">
                   Body
                 </p>
-                <p className="mt-1 text-sm leading-relaxed text-[var(--color-text-muted)]">
+                <p className="font-body mt-1 text-base leading-relaxed text-[var(--color-text-muted)]">
                   {result.original_script.body}
                 </p>
               </div>
 
               {/* Payoff */}
               <div>
-                <p className="text-xs font-semibold uppercase text-[var(--color-accent)]">
+                <p className="font-ui text-[9px] uppercase tracking-[0.14em] text-[var(--stud-b)]">
                   Payoff
                 </p>
-                <p className="mt-1 text-sm leading-relaxed">
+                <p className="font-body mt-1 text-base leading-relaxed">
                   {result.original_script.payoff}
                 </p>
               </div>
 
-              {/* Personalized version */}
-              <div className="rounded-lg bg-[var(--color-bg)] p-3">
-                <p className="text-xs font-semibold uppercase text-[var(--color-success)]">
-                  Personalized Script
+              {/* Personalized Script — the creator's voice version */}
+              <div className="rounded-[10px] bg-[var(--pers-d)]/30 border border-[var(--pers-c)]/40 p-5">
+                <p className="font-ui text-[9px] uppercase tracking-[0.14em] text-[var(--pers-b)]">
+                  In Your Voice
                 </p>
-                <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-[var(--color-text-muted)]">
+                <p className="font-body mt-2 whitespace-pre-wrap text-base leading-relaxed text-[var(--color-text-muted)]">
                   {result.personalized_script}
                 </p>
               </div>
 
-              {/* Meta */}
-              <div className="flex gap-4 text-xs text-[var(--color-text-muted)]">
-                <span>
-                  Duration: ~{result.original_script.estimated_duration.toFixed(0)}s
-                </span>
-                {result.original_script.structural_notes && (
-                  <span>Notes: {result.original_script.structural_notes}</span>
-                )}
-              </div>
+              {/* Structural notes */}
+              {result.original_script.structural_notes && (
+                <p className="font-ui text-[10px] text-[var(--color-text-light)]">
+                  {result.original_script.structural_notes}
+                </p>
+              )}
 
               {/* Video generation */}
               <VideoGenerator runId={runId} scriptId={result.script_id} />
@@ -266,26 +250,34 @@ function ScriptCard({
 
 function VideoPromptList({ results }: { results: FinalResult[] }) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       {results.map((result) => (
-        <Card key={result.script_id}>
-          <div className="flex items-start gap-3">
+        <Card key={result.script_id} padding="lg">
+          <div className="flex items-start gap-4">
             <span
-              className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
-                result.rank === 1
-                  ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)]"
-                  : "bg-[var(--color-border)] text-[var(--color-text-muted)]"
-              }`}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-display text-sm"
+              style={{
+                backgroundColor: result.rank === 1 ? "var(--pers-d)" : "rgba(14,12,20,0.04)",
+                color: result.rank === 1 ? "var(--pers-b)" : "var(--color-text-muted)",
+              }}
             >
               {result.rank}
             </span>
             <div className="min-w-0 flex-1">
-              <p className="whitespace-pre-wrap text-sm leading-relaxed text-[var(--color-text-muted)]">
+              <p className="font-ui text-[9px] uppercase tracking-[0.14em] text-[var(--pers-b)] mb-2">
+                Video Production Prompt
+              </p>
+              <p className="font-body whitespace-pre-wrap text-base leading-relaxed text-[var(--color-text-muted)]">
                 {result.video_prompt}
               </p>
-              <p className="mt-2 font-mono text-xs text-[var(--color-text-muted)]">
-                {result.script_id.slice(0, 12)} — {result.original_script.pattern_used}
-              </p>
+              <div className="mt-3 flex items-center gap-3">
+                <span className="font-ui text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-light)]">
+                  {result.original_script.pattern_used}
+                </span>
+                <span className="font-ui text-[10px] text-[var(--color-text-light)]">
+                  ~{result.original_script.estimated_duration.toFixed(0)}s
+                </span>
+              </div>
             </div>
           </div>
         </Card>
@@ -296,112 +288,64 @@ function VideoPromptList({ results }: { results: FinalResult[] }) {
 
 // ── Video Generator ───────────────────────────────────────
 
-function VideoGenerator({
-  runId,
-  scriptId,
-}: {
-  runId: string;
-  scriptId: string;
-}) {
+function VideoGenerator({ runId, scriptId }: { runId: string; scriptId: string }) {
   const [jobId, setJobId] = useState<string | null>(null);
   const [status, setStatus] = useState<VideoStatus | null>(null);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Clean up polling on unmount
   useEffect(() => {
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-    };
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
   }, []);
 
   const handleGenerate = useCallback(async () => {
     setGenerating(true);
     setError(null);
-
     try {
       const { job_id } = await generateVideo(runId, scriptId);
       setJobId(job_id);
-
-      // Start polling
       pollRef.current = setInterval(async () => {
         try {
           const vs = await getVideoStatus(runId, job_id);
           setStatus(vs);
-
           if (vs.status === "complete" || vs.status === "failed") {
             if (pollRef.current) clearInterval(pollRef.current);
             pollRef.current = null;
             setGenerating(false);
-
-            if (vs.status === "failed") {
-              setError(vs.error || "Video generation failed");
-            }
+            if (vs.status === "failed") setError(vs.error || "Video generation failed");
           }
-        } catch {
-          // Keep polling on transient errors
-        }
+        } catch { /* keep polling */ }
       }, 5000);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to start generation",
-      );
+      setError(err instanceof Error ? err.message : "Failed to start generation");
       setGenerating(false);
     }
   }, [runId, scriptId]);
 
   return (
-    <div className="border-t border-[var(--color-border)] pt-3">
+    <div className="border-t border-[var(--color-border)] pt-4">
       {!jobId && (
-        <Button
-          onClick={handleGenerate}
-          loading={generating}
-          size="sm"
-          variant="secondary"
-        >
+        <Button onClick={handleGenerate} loading={generating} size="sm" variant="secondary">
           Generate Video
         </Button>
       )}
-
       {jobId && status?.status === "processing" && (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <Spinner size="sm" />
-          <span className="text-sm text-[var(--color-text-muted)]">
+          <span className="font-body text-sm text-[var(--color-text-muted)]">
             Generating video...
           </span>
         </div>
       )}
-
       {status?.status === "complete" && status.video_url && (
-        <VideoPlayer url={status.video_url} />
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="overflow-hidden rounded-[10px]">
+          <video src={status.video_url} controls className="w-full rounded-[10px]" preload="metadata">
+            <track kind="captions" />
+          </video>
+        </motion.div>
       )}
-
-      {error && (
-        <p className="mt-2 text-sm text-[var(--color-error)]">{error}</p>
-      )}
+      {error && <p className="mt-2 font-ui text-[11px] text-[var(--eval-a)]">{error}</p>}
     </div>
-  );
-}
-
-// ── Video Player ──────────────────────────────────────────
-
-function VideoPlayer({ url }: { url: string }) {
-  return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      className="overflow-hidden rounded-lg"
-    >
-      <video
-        src={url}
-        controls
-        className="w-full rounded-lg"
-        preload="metadata"
-      >
-        <track kind="captions" />
-        Your browser does not support video playback.
-      </video>
-    </motion.div>
   );
 }

--- a/frontend/src/components/VotingAnimation.tsx
+++ b/frontend/src/components/VotingAnimation.tsx
@@ -1,13 +1,10 @@
 /**
- * Voting Animation — 100-avatar React island with live SSE voting.
+ * Voting Animation — 100-persona evaluation visualization.
  *
- * Displays a 10x10 grid of persona avatars. As vote_cast events arrive,
- * the corresponding avatar animates and the leaderboard updates.
+ * V2's unique feature: AI personas evaluate candidate scripts.
+ * Uses the Evaluate section color palette (rose/pink).
  *
- * Can show either the live voting (SSE connected) or the final results
- * (loaded from API after pipeline completes).
- *
- * Issue: https://github.com/yangyang-how/flair2/issues/37
+ * Design: V1 aesthetic with 10x10 persona grid and live leaderboard.
  */
 
 import { useMemo, useState } from "react";
@@ -40,59 +37,40 @@ function deriveVotingState(events: SSEEvent[]) {
 
   for (const evt of events) {
     const d = evt.data as Record<string, unknown>;
-
     switch (evt.event) {
       case "pipeline_started":
         totalPersonas = (d.total_personas as number) || 100;
         break;
-
       case "stage_started":
-        if (d.stage === "S4_MAP") {
-          totalPersonas = (d.total_items as number) || totalPersonas;
-        }
+        if (d.stage === "S4_MAP") totalPersonas = (d.total_items as number) || totalPersonas;
         break;
-
       case "vote_cast": {
         const personaId = d.persona_id as string;
         const top5 = (d.top_5 as string[]) || [];
         const completed = (d.completed as number) || votes.length + 1;
         const idx = completed - 1;
-
         if (!votedSet.has(idx)) {
           votedSet.add(idx);
           votes.push({ personaId, top5, index: idx });
-
-          for (const scriptId of top5) {
-            tally[scriptId] = (tally[scriptId] || 0) + 1;
-          }
+          for (const scriptId of top5) tally[scriptId] = (tally[scriptId] || 0) + 1;
         }
         break;
       }
-
       case "s5_complete":
         topIds = (d.top_ids as string[]) || [];
         break;
-
       case "pipeline_complete":
         pipelineDone = true;
         break;
     }
   }
 
-  // Build sorted leaderboard
   const leaderboard: LeaderboardEntry[] = Object.entries(tally)
     .map(([scriptId, voteCount]) => ({ scriptId, votes: voteCount }))
     .sort((a, b) => b.votes - a.votes)
     .slice(0, 10);
 
-  return {
-    votes,
-    votedSet,
-    leaderboard,
-    totalPersonas,
-    pipelineDone,
-    topIds,
-  };
+  return { votes, votedSet, leaderboard, totalPersonas, pipelineDone, topIds };
 }
 
 // ── Component ─────────────────────────────────────────────
@@ -105,16 +83,10 @@ export default function VotingAnimation({ runId }: VotingAnimationProps) {
   const { events, connected, error } = useSSE(runId);
   const [showGrid, setShowGrid] = useState(true);
 
-  const {
-    votes,
-    votedSet,
-    leaderboard,
-    totalPersonas,
-    pipelineDone,
-    topIds,
-  } = useMemo(() => deriveVotingState(events), [events]);
+  const { votedSet, leaderboard, totalPersonas, pipelineDone, topIds } =
+    useMemo(() => deriveVotingState(events), [events]);
 
-  const voteCount = votes.length;
+  const voteCount = votedSet.size;
   const progress = totalPersonas > 0 ? (voteCount / totalPersonas) * 100 : 0;
 
   return (
@@ -122,24 +94,23 @@ export default function VotingAnimation({ runId }: VotingAnimationProps) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold">Audience Vote</h2>
-          <p className="text-sm text-[var(--color-text-muted)]">
+          <h2 className="font-display text-[28px] tracking-[0.08em]">Audience Vote</h2>
+          <p className="font-body text-base text-[var(--color-text-muted)]">
             {pipelineDone
-              ? "Voting complete — see the winners below"
-              : `${voteCount}/${totalPersonas} votes cast`}
+              ? "Voting complete \u2014 see the winners below"
+              : `${voteCount} of ${totalPersonas} personas have voted`}
           </p>
         </div>
         <div className="flex items-center gap-3">
           <button
             onClick={() => setShowGrid((s) => !s)}
-            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            className="font-ui text-[10px] uppercase tracking-[0.1em] text-[var(--color-text-muted)] hover:text-[var(--color-ink)] transition-colors"
           >
             {showGrid ? "Hide grid" : "Show grid"}
           </button>
           <span
-            className={`h-2 w-2 rounded-full ${
-              connected ? "bg-[var(--color-success)]" : "bg-[var(--color-error)]"
-            }`}
+            className={`h-1.5 w-1.5 rounded-full ${connected ? "bg-[var(--eval-a)]" : "bg-[var(--color-text-light)]"}`}
+            style={connected ? { animation: "dotPulse 1.5s ease-in-out infinite" } : undefined}
           />
         </div>
       </div>
@@ -148,60 +119,47 @@ export default function VotingAnimation({ runId }: VotingAnimationProps) {
       <ProgressBar
         value={progress}
         label={`${voteCount} of ${totalPersonas} personas`}
+        color="var(--eval-a)"
       />
 
-      <div className="grid gap-6 lg:grid-cols-[1fr_300px]">
+      <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
         {/* Avatar grid */}
         <AnimatePresence>
           {showGrid && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-            >
-              <AvatarGrid
-                total={totalPersonas}
-                votedSet={votedSet}
-              />
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              <AvatarGrid total={totalPersonas} votedSet={votedSet} />
             </motion.div>
           )}
         </AnimatePresence>
 
         {/* Leaderboard */}
         <div className={showGrid ? "" : "lg:col-span-2 max-w-md mx-auto w-full"}>
-          <Leaderboard
-            entries={leaderboard}
-            topIds={topIds}
-            pipelineDone={pipelineDone}
-            maxVotes={totalPersonas}
-          />
+          <Leaderboard entries={leaderboard} pipelineDone={pipelineDone} maxVotes={totalPersonas} />
         </div>
       </div>
 
-      {/* Final actions */}
+      {/* Completion */}
       {pipelineDone && (
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
-          className="rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-4 text-center"
+          className="rounded-[10px] border border-[var(--stud-c)]/40 bg-[var(--stud-d)]/30 p-6 text-center"
         >
-          <p className="text-sm text-[var(--color-success)]">
-            Voting complete — {leaderboard[0]?.scriptId || "Script"} won with{" "}
-            {leaderboard[0]?.votes || 0} votes
+          <p className="font-body text-base text-[var(--stud-b)]">
+            Voting complete \u2014 {leaderboard[0]?.scriptId.slice(0, 8) || "Script"} won with {leaderboard[0]?.votes || 0} votes
           </p>
           <a
             href={`/results/${runId}`}
-            className="mt-2 inline-block rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--color-accent-hover)]"
+            className="mt-3 inline-block font-ui rounded-full bg-[var(--stud-b)] px-6 py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white hover:bg-[var(--stud-a)] transition-colors"
           >
             View Results
           </a>
         </motion.div>
       )}
 
-      {/* Error */}
       {error && !pipelineDone && (
-        <div className="rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/5 p-3">
-          <p className="text-sm text-[var(--color-error)]">{error}</p>
+        <div className="rounded-[10px] border border-[var(--eval-c)] bg-[var(--eval-d)]/30 p-4">
+          <p className="font-ui text-[11px] text-[var(--eval-b)]">{error}</p>
         </div>
       )}
     </div>
@@ -210,23 +168,23 @@ export default function VotingAnimation({ runId }: VotingAnimationProps) {
 
 // ── Avatar Grid ───────────────────────────────────────────
 
-function AvatarGrid({
-  total,
-  votedSet,
-}: {
-  total: number;
-  votedSet: Set<number>;
-}) {
-  // Generate stable colors for each avatar
+function AvatarGrid({ total, votedSet }: { total: number; votedSet: Set<number> }) {
+  // Use rose palette for voted avatars — evaluation stage color
   const colors = useMemo(() => {
-    const hues = Array.from({ length: total }, (_, i) => (i * 137.5) % 360);
-    return hues.map((h) => `hsl(${h}, 50%, 60%)`);
+    return Array.from({ length: total }, (_, i) => {
+      // Spread across the eval color range: light pink → rose → deep rose
+      const t = i / total;
+      const hue = 340 + t * 30; // 340-370 (rose range)
+      const sat = 55 + t * 20;
+      const light = 65 - t * 15;
+      return `hsl(${hue}, ${sat}%, ${light}%)`;
+    });
   }, [total]);
 
   return (
     <Card padding="sm">
       <div
-        className="grid gap-1"
+        className="grid gap-[3px]"
         style={{
           gridTemplateColumns: `repeat(${Math.min(10, Math.ceil(Math.sqrt(total)))}, 1fr)`,
         }}
@@ -236,28 +194,22 @@ function AvatarGrid({
           return (
             <motion.div
               key={i}
-              className="relative aspect-square rounded-md"
+              className="relative aspect-square rounded-[4px]"
               style={{
-                backgroundColor: hasVoted ? colors[i] : "var(--color-border)",
+                backgroundColor: hasVoted ? colors[i] : "rgba(14,12,20,0.04)",
               }}
               animate={
                 hasVoted
-                  ? {
-                      scale: [1, 1.2, 1],
-                      opacity: 1,
-                    }
-                  : { scale: 1, opacity: 0.3 }
+                  ? { scale: [1, 1.15, 1], opacity: 1 }
+                  : { scale: 1, opacity: 0.4 }
               }
-              transition={{
-                duration: 0.3,
-                ease: "easeOut",
-              }}
+              transition={{ duration: 0.3, ease: "easeOut" }}
             >
               {hasVoted && (
                 <motion.div
                   initial={{ scale: 0 }}
                   animate={{ scale: 1 }}
-                  className="absolute inset-0 flex items-center justify-center text-[8px] font-bold text-white/80"
+                  className="absolute inset-0 flex items-center justify-center font-ui text-[7px] font-medium text-white/70"
                 >
                   {i + 1}
                 </motion.div>
@@ -273,32 +225,27 @@ function AvatarGrid({
 // ── Leaderboard ───────────────────────────────────────────
 
 function Leaderboard({
-  entries,
-  topIds,
-  pipelineDone,
-  maxVotes,
+  entries, pipelineDone, maxVotes,
 }: {
   entries: LeaderboardEntry[];
-  topIds: string[];
   pipelineDone: boolean;
   maxVotes: number;
 }) {
   return (
     <Card padding="sm">
-      <h3 className="mb-3 text-sm font-semibold text-[var(--color-text-muted)]">
+      <h3 className="mb-3 font-display text-sm tracking-[0.12em]">
         Leaderboard
       </h3>
 
       {entries.length === 0 ? (
-        <p className="py-4 text-center text-sm text-[var(--color-text-muted)]">
+        <p className="py-6 text-center font-body text-sm text-[var(--color-text-muted)]">
           Waiting for votes...
         </p>
       ) : (
-        <div className="space-y-2">
+        <div className="space-y-1.5">
           <AnimatePresence mode="popLayout">
             {entries.map((entry, rank) => {
               const isWinner = pipelineDone && rank === 0;
-              const isFinalTop = topIds.includes(entry.scriptId);
               const barWidth = maxVotes > 0 ? (entry.votes / maxVotes) * 100 : 0;
 
               return (
@@ -307,30 +254,25 @@ function Leaderboard({
                   layout
                   initial={{ opacity: 0, x: -10 }}
                   animate={{ opacity: 1, x: 0 }}
-                  className={`flex items-center gap-2 rounded-md p-1.5 text-sm ${
-                    isWinner
-                      ? "bg-[var(--color-accent)]/10 border border-[var(--color-accent)]/20"
-                      : ""
+                  className={`flex items-center gap-2 rounded-[6px] p-1.5 ${
+                    isWinner ? "bg-[var(--eval-d)]/40 border border-[var(--eval-c)]/30" : ""
                   }`}
                 >
-                  <span className="w-5 shrink-0 text-right text-xs font-mono text-[var(--color-text-muted)]">
+                  <span className="w-5 shrink-0 text-right font-display text-xs text-[var(--color-text-muted)]">
                     {rank + 1}
                   </span>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center justify-between">
-                      <span className="truncate font-mono text-xs">
+                      <span className="truncate font-ui text-[10px] tracking-[0.04em]">
                         {entry.scriptId.slice(0, 8)}
-                        {isFinalTop && pipelineDone && (
-                          <span className="ml-1 text-[var(--color-success)]">*</span>
-                        )}
                       </span>
-                      <span className="ml-2 shrink-0 text-xs font-medium text-[var(--color-text-muted)]">
+                      <span className="ml-2 shrink-0 font-display text-xs text-[var(--eval-b)]">
                         {entry.votes}
                       </span>
                     </div>
-                    <div className="mt-1 h-1 overflow-hidden rounded-full bg-[var(--color-bg)]">
+                    <div className="mt-1 h-[2px] overflow-hidden rounded-full bg-[rgba(14,12,20,0.04)]">
                       <motion.div
-                        className="h-full rounded-full bg-[var(--color-accent)]"
+                        className="h-full rounded-full bg-[var(--eval-a)]"
                         initial={{ width: 0 }}
                         animate={{ width: `${barWidth}%` }}
                         transition={{ duration: 0.3 }}


### PR DESCRIPTION
## Summary

Follow-up to #114. Restyles the two main React islands for V2's text-first output (no images).

**Key design decisions for V2 vs V1:**
- V1 produced images → phone mockups, storyboard grids, hero images
- V2 produces scripts + prompts → hook text gets hero treatment (large Cormorant Garamond), script sections are color-coded by pipeline stage, video prompts are labeled as "Production Prompt"

**Color mapping by pipeline section:**
- Hook labels: Discovery gold (S1-S2 extracted the patterns)
- Body/Payoff labels: Studio teal (S3 generated the scripts)
- Personalized section: Personalize purple with tinted bg (S6 adapted to voice)
- Vote scores/ranks: Evaluate rose (S4-S5 determined ranking)
- Avatar grid: Rose palette (evaluation stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)