### PR TITLE
chore: migrate CI/CD to personal AWS account

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  ECR_REGISTRY: 966294739208.dkr.ecr.us-west-2.amazonaws.com
+  ECR_REGISTRY: 314727362981.dkr.ecr.us-west-2.amazonaws.com
   ECR_API_REPO: flair2-dev-api
   ECR_WORKER_REPO: flair2-dev-worker
   ECS_CLUSTER: flair2-dev-cluster
@@ -32,7 +32,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to ECR
@@ -109,7 +108,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Get ALB URL

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ on:
 env:
   AWS_REGION: us-west-2
   ECS_CLUSTER: flair2-dev-cluster
-  ECR_REGISTRY: 966294739208.dkr.ecr.us-west-2.amazonaws.com
+  ECR_REGISTRY: 314727362981.dkr.ecr.us-west-2.amazonaws.com
   ECR_REPO: flair2-dev-api
 
 jobs:
@@ -39,7 +39,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ env.AWS_REGION }}
 
       # Resolve the ElastiCache endpoint at runtime — no hardcoded URLs

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -62,7 +62,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
       AWS_DEFAULT_REGION: us-west-2
 
     steps:
@@ -93,7 +92,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
       AWS_DEFAULT_REGION: us-west-2
 
     steps:
@@ -122,7 +120,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
       AWS_DEFAULT_REGION: us-west-2
 
     steps:


### PR DESCRIPTION
## Summary
- Remove `AWS_SESSION_TOKEN` from all three workflows — not needed for IAM user long-term keys (was Learner Lab specific)
- Update ECR registry account ID from `966294739208` (Learner Lab) to `314727362981` (personal account)
- Region stays `us-west-2` (Oregon — closest to Vancouver)

## Before merging
Add these two secrets to repo Settings → Secrets and variables → Actions:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

(Remove the old `AWS_SESSION_TOKEN` secret if it exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)