### PR TITLE
chore: update kimi secret ARN to personal AWS account

### DIFF
--- a/terraform/environments/dev.tfvars
+++ b/terraform/environments/dev.tfvars
@@ -11,7 +11,7 @@ availability_zones   = ["us-west-2a", "us-west-2b"]
 # Create the Kimi API key secret manually before apply:
 #   aws secretsmanager create-secret --name flair2/dev/kimi-api-key --secret-string "YOUR_KEY"
 # Then paste the ARN returned by the command here.
-kimi_api_key_secret_arn = "arn:aws:secretsmanager:us-west-2:966294739208:secret:flair2/dev/kimi-api-key-JYvv9k"
+kimi_api_key_secret_arn = "arn:aws:secretsmanager:us-west-2:314727362981:secret:flair2/dev/kimi-api-key-JNzWmi"
 
 # ── ECS Autoscaling ───────────────────────────────────────────────────────────
 # AppAutoScaling keeps tasks between min and max based on CPU utilisation.


### PR DESCRIPTION
## Summary
- Update `kimi_api_key_secret_arn` in `terraform/environments/dev.tfvars` from Learner Lab account (`966294739208`) to personal account (`314727362981`)
- Secret was already created in Secrets Manager via CLI

Missed from #116 — that PR was merged before this commit was pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)