### PR TITLE
chore: rename terraform state bucket to include account ID

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -68,15 +68,15 @@ jobs:
       - name: Create S3 state bucket (idempotent)
         working-directory: .
         run: |
-          if aws s3api head-bucket --bucket flair2-terraform-state 2>/dev/null; then
+          if aws s3api head-bucket --bucket flair2-terraform-state-314727362981 2>/dev/null; then
             echo "Bucket already exists — skipping creation"
           else
             aws s3api create-bucket \
-              --bucket flair2-terraform-state \
+              --bucket flair2-terraform-state-314727362981 \
               --region us-west-2 \
               --create-bucket-configuration LocationConstraint=us-west-2
             aws s3api put-bucket-versioning \
-              --bucket flair2-terraform-state \
+              --bucket flair2-terraform-state-314727362981 \
               --versioning-configuration Status=Enabled
             echo "Bucket created and versioning enabled"
           fi

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,7 +14,7 @@ terraform {
   #   terraform init -backend-config="key=env/prod/terraform.tfstate"
   # This keeps dev and prod state isolated in the same bucket.
   backend "s3" {
-    bucket = "flair2-terraform-state"
+    bucket = "flair2-terraform-state-314727362981"
     key    = "env/dev/terraform.tfstate"
     region = "us-west-2"
   }


### PR DESCRIPTION
## Summary
- Rename `flair2-terraform-state` → `flair2-terraform-state-314727362981`
- The old name conflicts globally (likely held by Learner Lab account) causing `OperationAborted` on every bootstrap attempt
- Including account ID in bucket name is AWS best practice for guaranteed uniqueness

Fixes bootstrap failure in Terraform #35 and #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)