### PR TITLE
fix: replace LabRole with real IAM roles for personal AWS account

### DIFF
--- a/terraform/environments/dev.tfvars
+++ b/terraform/environments/dev.tfvars
@@ -1,5 +1,6 @@
-project = "flair2"
-env     = "dev"
+project    = "flair2"
+env        = "dev"
+account_id = "314727362981"
 
 aws_region = "us-west-2"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -211,9 +211,10 @@ resource "aws_security_group" "elasticache" {
 # ── Modules ───────────────────────────────────────────────────────────────────
 
 module "iam" {
-  source  = "./modules/iam"
-  project = var.project
-  env     = var.env
+  source     = "./modules/iam"
+  project    = var.project
+  env        = var.env
+  account_id = var.account_id
 }
 
 module "s3" {

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,7 +1,144 @@
-# Learner Lab does not allow creating IAM roles or policies.
-# The lab pre-provisions a single "LabRole" with broad permissions.
-# We reference it here so other modules can use it for ECS and Lambda.
+locals {
+  prefix = "${var.project}-${var.env}"
+}
 
-data "aws_iam_role" "lab_role" {
-  name = "LabRole"
+# ── ECS Task Execution Role ───────────────────────────────────────────────────
+# Used by the ECS agent (not the app) to:
+#   - Pull images from ECR
+#   - Write logs to CloudWatch
+#   - Fetch secrets from Secrets Manager (kimi API key)
+
+resource "aws_iam_role" "ecs_execution" {
+  name = "${local.prefix}-ecs-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = { Name = "${local.prefix}-ecs-execution-role" }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_managed" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow execution role to read secrets (kimi API key injected via ECS secrets field)
+resource "aws_iam_role_policy" "ecs_execution_secrets" {
+  name = "${local.prefix}-ecs-execution-secrets"
+  role = aws_iam_role.ecs_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = "arn:aws:secretsmanager:*:${var.account_id}:secret:${var.project}/*"
+    }]
+  })
+}
+
+# ── ECS Task Role ─────────────────────────────────────────────────────────────
+# Used by the application code running inside containers to access AWS services:
+#   - S3 (pipeline assets)
+#   - DynamoDB (pipeline runs + video performance tables)
+#   - CloudWatch logs
+
+resource "aws_iam_role" "ecs_task" {
+  name = "${local.prefix}-ecs-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = { Name = "${local.prefix}-ecs-task-role" }
+}
+
+resource "aws_iam_role_policy" "ecs_task_permissions" {
+  name = "${local.prefix}-ecs-task-permissions"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.project}-pipeline-${var.env}",
+          "arn:aws:s3:::${var.project}-pipeline-${var.env}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem", "dynamodb:Query", "dynamodb:Scan"
+        ]
+        Resource = [
+          "arn:aws:dynamodb:*:${var.account_id}:table/${var.project}-${var.env}-*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream", "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:${var.account_id}:log-group:/ecs/${local.prefix}/*"
+      }
+    ]
+  })
+}
+
+# ── Lambda Execution Role ─────────────────────────────────────────────────────
+# Used by the Lambda function (S7 video generation) to:
+#   - Write logs to CloudWatch
+#   - Read/write S3
+
+resource "aws_iam_role" "lambda" {
+  name = "${local.prefix}-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = { Name = "${local.prefix}-lambda-role" }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "lambda_s3" {
+  name = "${local.prefix}-lambda-s3"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["s3:GetObject", "s3:PutObject"]
+      Resource = [
+        "arn:aws:s3:::${var.project}-pipeline-${var.env}/*"
+      ]
+    }]
+  })
 }

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,14 +1,14 @@
 output "ecs_execution_role_arn" {
-  description = "ARN of the ECS task execution role (LabRole — Learner Lab pre-provisioned)"
-  value       = data.aws_iam_role.lab_role.arn
+  description = "ARN of the ECS task execution role"
+  value       = aws_iam_role.ecs_execution.arn
 }
 
 output "ecs_task_role_arn" {
-  description = "ARN of the ECS task role (LabRole — Learner Lab pre-provisioned)"
-  value       = data.aws_iam_role.lab_role.arn
+  description = "ARN of the ECS task role"
+  value       = aws_iam_role.ecs_task.arn
 }
 
 output "lambda_role_arn" {
-  description = "ARN of the Lambda execution role (LabRole — Learner Lab pre-provisioned)"
-  value       = data.aws_iam_role.lab_role.arn
+  description = "ARN of the Lambda execution role"
+  value       = aws_iam_role.lambda.arn
 }

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -7,3 +7,8 @@ variable "env" {
   description = "Deployment environment: dev or prod"
   type        = string
 }
+
+variable "account_id" {
+  description = "AWS account ID — used to scope IAM policy resource ARNs"
+  type        = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,8 @@
+variable "account_id" {
+  description = "AWS account ID — used to scope IAM policy resource ARNs"
+  type        = string
+}
+
 variable "project" {
   description = "Project name — used as a prefix for all resource names"
   type        = string


### PR DESCRIPTION
## Summary
- Rewrite `terraform/modules/iam/main.tf` — was a 7-line stub that just referenced Learner Lab's pre-provisioned `LabRole` (which doesn't exist in a personal account)
- Create three proper IAM roles:
  - `ecs-execution-role` — ECS agent: ECR pull, CloudWatch logs, Secrets Manager read
  - `ecs-task-role` — App containers: S3, DynamoDB, CloudWatch logs
  - `lambda-role` — Lambda: CloudWatch logs, S3
- Add `account_id` variable to scope IAM policy ARNs to the correct account
- Pass `account_id = "314727362981"` in `dev.tfvars`

## Root cause
Terraform `apply` was failing with:
```
Error: reading IAM Role (LabRole): couldn't find resource
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)