### PR TITLE
fix: copy pyproject.toml into runtime image for pytest config

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 # Copy venv from builder
 COPY --from=builder /app/venv /app/venv
 
-# Copy application code and tests
+# Copy application code, tests, and pytest config
+COPY pyproject.toml .
 COPY app/ ./app/
 COPY tests/ ./tests/
 


### PR DESCRIPTION
## Summary
- Copy `pyproject.toml` into the Docker runtime stage
- `asyncio_mode = "auto"` lives in `pyproject.toml` but it was only present in the builder stage, not the runtime image
- pytest falling back to strict mode caused all 6 async integration tests to fail with `async def functions are not natively supported`

## Root cause
```
# Runtime stage was missing this line:
COPY pyproject.toml .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)