### PR TITLE
fix: fallback for crypto.randomUUID on HTTP (S3 static site)

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -156,7 +156,7 @@ export function getSessionId(): string {
   if (typeof window === "undefined") return "ssr";
   let id = localStorage.getItem(SESSION_KEY);
   if (!id) {
-    id = crypto.randomUUID();
+    id = crypto.randomUUID?.() ?? Math.random().toString(36).slice(2) + Date.now().toString(36);
     localStorage.setItem(SESSION_KEY, id);
   }
   return id;


### PR DESCRIPTION
## Summary
- `crypto.randomUUID()` requires HTTPS — unavailable on S3 static website (HTTP)
- Add `?.()` optional call + `??` fallback using `Math.random` + `Date.now`
- HTTPS environments (e.g. CloudFront) still use the native UUID

## Root cause
```
Failed to start pipeline: crypto.randomUUID is not a function
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)