### PR TITLE
fix: add -s flag to show M6 experiment results in CloudWatch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,7 +93,7 @@ jobs:
                 \"name\": \"worker\",
                 \"command\": [\"python\", \"-m\", \"pytest\",
                               \"tests/experiments/test_elasticache_integration.py\",
-                              \"-v\", \"--tb=short\", \"--no-header\"],
+                              \"-v\", \"--tb=short\", \"--no-header\", \"-s\"],
                 \"environment\": [{
                   \"name\": \"ELASTICACHE_URL\",
                   \"value\": \"${{ steps.elasticache.outputs.url }}\"


### PR DESCRIPTION
## Summary
- Add `-s` to the pytest command in the ECS integration test task
- pytest captures stdout by default; M6 latency (p50/p95/p99) and memory numbers were invisible on passing runs
- After this change, results appear in CloudWatch under `/ecs/flair2-dev/worker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)