### PR TITLE
fix: copy data/ into runtime Docker image for dataset access

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,10 +29,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 # Copy venv from builder
 COPY --from=builder /app/venv /app/venv
 
-# Copy application code, tests, and pytest config
+# Copy application code, tests, pytest config, and dataset
 COPY pyproject.toml .
 COPY app/ ./app/
 COPY tests/ ./tests/
+COPY data/ ./data/
 
 # Use venv python
 ENV PATH="/app/venv/bin:$PATH" \


### PR DESCRIPTION
## Summary
- Adds `COPY data/ ./data/` to the runtime stage of `backend/Dockerfile`
- The dataset file (`data/sample_videos.json`) was missing from the container, causing all `POST /api/pipeline/start` requests to return 500 with `"Dataset not found. Check the FLAIR2_DATASET_PATH configuration."`

## Root cause
The builder stage copied `app/`, `tests/`, and `pyproject.toml` but omitted the `data/` directory. At runtime the app looked for `data/sample_videos.json` relative to `/app` and found nothing.

## Test plan
- [ ] Merge and wait for Deploy workflow to complete
- [ ] Re-run Locust with K=10 and confirm `/api/pipeline/start` failure count drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)