### PR TITLE
fix: remove data/ from .dockerignore so dataset is included in image

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -15,9 +15,6 @@ venv/
 env/
 
 
-# Data files (sample_videos.json, results.json — not needed in image)
-data/
-
 # Dev / local config
 .env
 .env.*


### PR DESCRIPTION
## Summary
- Removes `data/` from `backend/.dockerignore`
- `.dockerignore` was explicitly excluding the dataset directory, so `COPY data/ ./data/` in the Dockerfile (added in #125) had nothing to copy — causing the Docker build to fail with `"/data": not found`

## Root cause chain
1. `backend/app/config.py` defaults `dataset_path` to `data/sample_videos.json`
2. `backend/Dockerfile` (fixed in #125) adds `COPY data/ ./data/`
3. `backend/.dockerignore` excluded `data/` — blocking the COPY

## Test plan
- [ ] Merge and confirm Deploy workflow passes (Backend — Docker → ECR → ECS goes green)
- [ ] Re-run Locust K=10 and confirm `/api/pipeline/start` failure count drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)