### PR TITLE
feat: enable ECS Exec on API and Worker services

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -93,11 +93,12 @@ resource "aws_ecs_task_definition" "api" {
 # 2 replicas behind the ALB target group
 
 resource "aws_ecs_service" "api" {
-  name            = "${local.prefix}-api"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.api.arn
-  desired_count   = var.api_desired_count
-  launch_type     = "FARGATE"
+  name                   = "${local.prefix}-api"
+  cluster                = aws_ecs_cluster.main.id
+  task_definition        = aws_ecs_task_definition.api.arn
+  desired_count          = var.api_desired_count
+  launch_type            = "FARGATE"
+  enable_execute_command = true
 
   network_configuration {
     subnets          = var.private_subnet_ids
@@ -180,11 +181,12 @@ resource "aws_ecs_task_definition" "worker" {
 # No ALB — workers pull work from Redis, no inbound traffic needed
 
 resource "aws_ecs_service" "worker" {
-  name            = "${local.prefix}-worker"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.worker.arn
-  desired_count   = var.worker_desired_count
-  launch_type     = "FARGATE"
+  name                   = "${local.prefix}-worker"
+  cluster                = aws_ecs_cluster.main.id
+  task_definition        = aws_ecs_task_definition.worker.arn
+  desired_count          = var.worker_desired_count
+  launch_type            = "FARGATE"
+  enable_execute_command = true
 
   network_configuration {
     subnets          = var.private_subnet_ids


### PR DESCRIPTION
## Summary
- Adds `enable_execute_command = true` to both `aws_ecs_service.api` and `aws_ecs_service.worker`

## Why
Enables `aws ecs execute-command` to shell into running ECS tasks for live debugging. Primary use case: checking Redis Celery queue depth during load tests to verify the Worker bottleneck hypothesis:

```bash
aws ecs execute-command \
  --cluster flair2-dev-cluster \
  --task <task-id> \
  --container worker \
  --interactive \
  --command "redis-cli -u $REDIS_URL -n 1 LLEN celery"
```

This lets us directly measure queue backlog during K=500 Locust runs, confirming whether Celery queue depth (not CPU) is the true scaling signal for the Worker service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)