### PR TITLE
fix: add ssmmessages permissions to ECS task role for ECS Exec

### DIFF
--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -97,6 +97,16 @@ resource "aws_iam_role_policy" "ecs_task_permissions" {
           "logs:CreateLogStream", "logs:PutLogEvents"
         ]
         Resource = "arn:aws:logs:*:${var.account_id}:log-group:/ecs/${local.prefix}/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- Adds `ssmmessages:*` permissions to the ECS task role
- Required for `aws ecs execute-command` (ECS Exec) to connect to running containers

## Root cause
`enable_execute_command = true` was added to ECS services in #129, but the task IAM role was missing the `ssmmessages` permissions needed for the SSM agent inside the container to connect back to Systems Manager.

## After merge
1. Trigger Terraform Apply
2. Force new deployment on worker/api services
3. `aws ecs execute-command` will connect successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)