### PR TITLE
fix: use query params for S3 client-side routing

### DIFF
--- a/frontend/src/components/PipelineVisualizer.tsx
+++ b/frontend/src/components/PipelineVisualizer.tsx
@@ -201,7 +201,7 @@ export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
     if (pipelineDone && !redirecting) {
       setRedirecting(true);
       const timer = setTimeout(() => {
-        window.location.href = `/vote/${runId}`;
+        window.location.href = `/vote/?id=${runId}`;
       }, 2000);
       return () => clearTimeout(timer);
     }
@@ -305,7 +305,7 @@ export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
               Pipeline complete — redirecting to voting results...
             </p>
             <a
-              href={`/vote/${runId}`}
+              href={`/vote/?id=${runId}`}
               className="mt-2 inline-block text-sm text-[var(--color-accent)] hover:underline"
             >
               Go now

--- a/frontend/src/components/ResultsPage.tsx
+++ b/frontend/src/components/ResultsPage.tsx
@@ -25,7 +25,7 @@ export default function ResultsPage() {
         <span className="mx-2">/</span>
         <a href="/runs" className="hover:text-[var(--color-text)]">Runs</a>
         <span className="mx-2">/</span>
-        <a href={`/pipeline/${id}`} className="hover:text-[var(--color-text)]">Pipeline</a>
+        <a href={`/pipeline/?id=${id}`} className="hover:text-[var(--color-text)]">Pipeline</a>
         <span className="mx-2">/</span>
         <span className="text-[var(--color-text)]">Results</span>
       </nav>

--- a/frontend/src/components/ResultsView.tsx
+++ b/frontend/src/components/ResultsView.tsx
@@ -68,7 +68,7 @@ export default function ResultsView({ runId }: ResultsViewProps) {
         </p>
         <p className="mt-2 font-body text-base text-[var(--color-text-muted)]">{error}</p>
         <a
-          href={`/pipeline/${runId}`}
+          href={`/pipeline/?id=${runId}`}
           className="mt-4 inline-block font-ui text-[11px] uppercase tracking-[0.1em] text-[var(--stud-b)] hover:underline"
         >
           Check pipeline status

--- a/frontend/src/components/RouteParam.tsx
+++ b/frontend/src/components/RouteParam.tsx
@@ -1,21 +1,26 @@
 /**
  * Client-side route parameter extraction.
  *
- * Reads the ID from the URL path (e.g. /pipeline/abc123 → "abc123").
- * Used instead of Astro.params for static (S3) hosting where there's
- * no server to parse dynamic route segments.
+ * Reads the ID from the URL query string (e.g. /pipeline/?id=abc123 → "abc123").
+ * Query params work on S3 static hosting where path-based routing would 404.
  */
 
 import { useEffect, useState } from "react";
 
 /**
- * Extract a path segment by position from the current URL.
- * position=1 means the second segment: /pipeline/[this-one]
+ * Extract the "id" query parameter from the current URL.
+ * Falls back to path segment extraction for backward compatibility.
  */
 export function useRouteId(position: number = 1): string | null {
   const [id, setId] = useState<string | null>(null);
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const queryId = params.get("id");
+    if (queryId) {
+      setId(queryId);
+      return;
+    }
     const segments = window.location.pathname.split("/").filter(Boolean);
     setId(segments[position] || null);
   }, [position]);

--- a/frontend/src/components/VotePage.tsx
+++ b/frontend/src/components/VotePage.tsx
@@ -25,7 +25,7 @@ export default function VotePage() {
         <span className="mx-2">/</span>
         <a href="/runs" className="hover:text-[var(--color-text)]">Runs</a>
         <span className="mx-2">/</span>
-        <a href={`/pipeline/${id}`} className="hover:text-[var(--color-text)]">Pipeline</a>
+        <a href={`/pipeline/?id=${id}`} className="hover:text-[var(--color-text)]">Pipeline</a>
         <span className="mx-2">/</span>
         <span className="text-[var(--color-text)]">Vote</span>
       </nav>

--- a/frontend/src/components/VotingAnimation.tsx
+++ b/frontend/src/components/VotingAnimation.tsx
@@ -149,7 +149,7 @@ export default function VotingAnimation({ runId }: VotingAnimationProps) {
             Voting complete \u2014 {leaderboard[0]?.scriptId.slice(0, 8) || "Script"} won with {leaderboard[0]?.votes || 0} votes
           </p>
           <a
-            href={`/results/${runId}`}
+            href={`/results/?id=${runId}`}
             className="mt-3 inline-block font-ui rounded-full bg-[var(--stud-b)] px-6 py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white hover:bg-[var(--stud-a)] transition-colors"
           >
             View Results

--- a/frontend/src/pages/create.astro
+++ b/frontend/src/pages/create.astro
@@ -374,7 +374,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         top_n: parseInt((document.getElementById("top_n") as HTMLInputElement).value) || 10,
       });
 
-      window.location.href = `/pipeline/${run_id}`;
+      window.location.href = `/pipeline/?id=${run_id}`;
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
       showError(`Failed to start pipeline: ${msg}`);


### PR DESCRIPTION
## Summary
- S3 static hosting returns 404 for paths like `/pipeline/{uuid}` — no physical file exists there
- S3's error document serves root `index.html` (home page), so the user gets bounced back to the landing page
- Fix: change all navigation from `/page/{id}` to `/page/?id={id}` — S3 resolves `/page/index.html` correctly and ignores the query string
- `RouteParam.tsx` now reads from `URLSearchParams` first, falls back to path segments for backward compatibility

## Changed files
- `RouteParam.tsx` — read `?id=` query param
- `create.astro` — redirect to `/pipeline/?id={runId}`
- `PipelineVisualizer.tsx` — redirect to `/vote/?id={runId}`
- `VotingAnimation.tsx` — link to `/results/?id={runId}`
- `VotePage.tsx`, `ResultsPage.tsx`, `ResultsView.tsx` — breadcrumb links

## Test plan
- [ ] CI passes
- [ ] Merge and deploy
- [ ] Click "Start Pipeline" on `/create/` — should navigate to `/pipeline/?id={uuid}` and show pipeline progress
- [ ] Pipeline completion should redirect to `/vote/?id={uuid}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)