### PR TITLE
fix: show real pipeline progress, not simulated state

### DIFF
--- a/frontend/src/components/PipelineVisualizer.tsx
+++ b/frontend/src/components/PipelineVisualizer.tsx
@@ -74,13 +74,6 @@ function deriveStageStates(events: SSEEvent[]): {
       case "stage_started": {
         const stageId = d.stage as string;
         if (stages[stageId]) {
-          // Mark all prior stages as completed
-          for (const s of STAGES) {
-            if (s.id === stageId) break;
-            if (stages[s.id].status !== "completed") {
-              stages[s.id] = { status: "completed", progress: 100, detail: "" };
-            }
-          }
           stages[stageId] = {
             status: "running",
             progress: 0,
@@ -187,14 +180,28 @@ interface PipelineVisualizerProps {
   runId: string;
 }
 
+const STALL_TIMEOUT_MS = 30_000;
+
 export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
   const { events, connected, error } = useSSE(runId);
   const [redirecting, setRedirecting] = useState(false);
+  const [stalled, setStalled] = useState(false);
 
   const { stages, pipelineDone, pipelineError } = useMemo(
     () => deriveStageStates(events),
     [events],
   );
+
+  // Stall detection: warn if no events arrive for 30s while connected
+  useEffect(() => {
+    if (!connected || pipelineDone || pipelineError) {
+      setStalled(false);
+      return;
+    }
+    setStalled(false);
+    const timer = setTimeout(() => setStalled(true), STALL_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [events.length, connected, pipelineDone, pipelineError]);
 
   // Auto-redirect to vote page on completion
   useEffect(() => {
@@ -215,12 +222,12 @@ export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
         <div className="flex items-center gap-2">
           <span
             className={`h-1.5 w-1.5 rounded-full ${
-              connected ? "bg-[var(--stud-a)]" : "bg-[var(--eval-a)]"
+              stalled ? "bg-[var(--color-warning, #f59e0b)]" : connected ? "bg-[var(--stud-a)]" : "bg-[var(--eval-a)]"
             }`}
-            style={connected ? { animation: "dotPulse 1.5s ease-in-out infinite" } : undefined}
+            style={connected && !stalled ? { animation: "dotPulse 1.5s ease-in-out infinite" } : undefined}
           />
           <span className="font-ui text-[10px] uppercase tracking-[0.1em] text-[var(--color-text-muted)]">
-            {connected ? "Live" : error || "Disconnected"}
+            {stalled ? "Stalled" : connected ? "Live" : error || "Disconnected"}
           </span>
         </div>
       </div>
@@ -273,6 +280,25 @@ export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
           </span>
         </motion.div>
       </div>
+
+      {/* Stall warning */}
+      <AnimatePresence>
+        {stalled && !pipelineError && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="rounded-lg border border-[var(--color-warning, #f59e0b)]/30 bg-[var(--color-warning, #f59e0b)]/5 p-4"
+          >
+            <p className="text-sm font-medium text-[var(--color-warning, #f59e0b)]">
+              Pipeline appears stalled
+            </p>
+            <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+              No progress events received for 30 seconds. Workers may be failing silently — check CloudWatch logs.
+            </p>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Error banner */}
       <AnimatePresence>

--- a/frontend/src/components/PipelineVisualizer.tsx
+++ b/frontend/src/components/PipelineVisualizer.tsx
@@ -52,16 +52,24 @@ function initialStageStates(): Record<string, StageState> {
 
 // ── Derive stage states from SSE events ───────────────────
 
+interface RunConfig {
+  totalVideos: number;
+  totalPersonas: number;
+  topN: number;
+}
+
 function deriveStageStates(events: SSEEvent[]): {
   stages: Record<string, StageState>;
   pipelineDone: boolean;
   pipelineError: string | null;
   runId: string | null;
+  runConfig: RunConfig | null;
 } {
   const stages = initialStageStates();
   let pipelineDone = false;
   let pipelineError: string | null = null;
   let runId: string | null = null;
+  let runConfig: RunConfig | null = null;
 
   for (const evt of events) {
     const d = evt.data as Record<string, unknown>;
@@ -69,6 +77,11 @@ function deriveStageStates(events: SSEEvent[]): {
     switch (evt.event) {
       case "pipeline_started":
         runId = (d.run_id as string) || null;
+        runConfig = {
+          totalVideos: (d.total_videos as number) || 0,
+          totalPersonas: (d.total_personas as number) || 0,
+          topN: (d.top_n as number) || 0,
+        };
         break;
 
       case "stage_started": {
@@ -171,7 +184,7 @@ function deriveStageStates(events: SSEEvent[]): {
     }
   }
 
-  return { stages, pipelineDone, pipelineError, runId };
+  return { stages, pipelineDone, pipelineError, runId, runConfig };
 }
 
 // ── Component ─────────────────────────────────────────────
@@ -187,10 +200,25 @@ export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
   const [redirecting, setRedirecting] = useState(false);
   const [stalled, setStalled] = useState(false);
 
-  const { stages, pipelineDone, pipelineError } = useMemo(
+  const { stages, pipelineDone, pipelineError, runConfig } = useMemo(
     () => deriveStageStates(events),
     [events],
   );
+
+  // Elapsed timer
+  const [elapsed, setElapsed] = useState(0);
+  const startTimeRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (events.length > 0 && !startTimeRef.current) {
+      startTimeRef.current = Date.now();
+    }
+    if (pipelineDone || pipelineError) return;
+    if (!startTimeRef.current) return;
+    const tick = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startTimeRef.current!) / 1000));
+    }, 1000);
+    return () => clearInterval(tick);
+  }, [events.length, pipelineDone, pipelineError]);
 
   // Stall detection: warn if no events arrive for 30s while connected
   useEffect(() => {
@@ -231,6 +259,28 @@ export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
           </span>
         </div>
       </div>
+
+      {/* Run info bar */}
+      {(runConfig || elapsed > 0) && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md bg-[var(--color-surface)] px-3 py-2 font-mono text-[11px] text-[var(--color-text-muted)]">
+          {elapsed > 0 && (
+            <span>
+              {pipelineDone ? "Completed in" : "Elapsed"}{" "}
+              <span className="text-[var(--color-text)]">
+                {elapsed >= 60 ? `${Math.floor(elapsed / 60)}m ${elapsed % 60}s` : `${elapsed}s`}
+              </span>
+            </span>
+          )}
+          {runConfig && (
+            <>
+              <span>{runConfig.totalVideos} videos</span>
+              <span>{runConfig.totalPersonas} personas</span>
+              <span>top {runConfig.topN}</span>
+            </>
+          )}
+          <span>{events.length} events received</span>
+        </div>
+      )}
 
       {/* Stage nodes */}
       <div className="space-y-3">
@@ -380,6 +430,31 @@ function formatEventLabel(evt: SSEEvent): { label: string; detail: string; color
   }
 }
 
+function EventRow({ evt }: { evt: SSEEvent }) {
+  const [expanded, setExpanded] = useState(false);
+  const { label, detail, color } = formatEventLabel(evt);
+  const time = evt.timestamp ? new Date(evt.timestamp).toLocaleTimeString() : "";
+
+  return (
+    <div>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-start gap-2 px-3 py-1.5 font-mono text-[11px] text-left hover:bg-[var(--color-surface)]/50 transition-colors"
+      >
+        <span className="shrink-0 text-[var(--color-text-muted)] opacity-50 w-16">{time}</span>
+        <span className="shrink-0" style={{ color }}>{label}</span>
+        {detail && <span className="text-[var(--color-text-muted)] truncate">{detail}</span>}
+        <span className="ml-auto shrink-0 text-[var(--color-text-muted)] opacity-30">{expanded ? "-" : "+"}</span>
+      </button>
+      {expanded && (
+        <pre className="mx-3 mb-1.5 overflow-x-auto rounded bg-[var(--color-bg, #000)]/60 p-2 text-[10px] text-[var(--color-text-muted)]">
+          {JSON.stringify(evt.data, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
 function ActivityLog({ events }: { events: SSEEvent[] }) {
   const [open, setOpen] = useState(false);
   const logEndRef = useRef<HTMLDivElement>(null);
@@ -428,27 +503,9 @@ function ActivityLog({ events }: { events: SSEEvent[] }) {
                 </p>
               ) : (
                 <div className="divide-y divide-[var(--color-border)]/50">
-                  {events.map((evt, i) => {
-                    const { label, detail, color } = formatEventLabel(evt);
-                    const time = evt.timestamp
-                      ? new Date(evt.timestamp).toLocaleTimeString()
-                      : "";
-                    return (
-                      <div key={evt.id || i} className="flex items-start gap-2 px-3 py-1.5 font-mono text-[11px]">
-                        <span className="shrink-0 text-[var(--color-text-muted)] opacity-50 w-16">
-                          {time}
-                        </span>
-                        <span className="shrink-0" style={{ color }}>
-                          {label}
-                        </span>
-                        {detail && (
-                          <span className="text-[var(--color-text-muted)] truncate">
-                            {detail}
-                          </span>
-                        )}
-                      </div>
-                    );
-                  })}
+                  {events.map((evt, i) => (
+                    <EventRow key={evt.id || i} evt={evt} />
+                  ))}
                   <div ref={logEndRef} />
                 </div>
               )}

--- a/frontend/src/components/PipelineVisualizer.tsx
+++ b/frontend/src/components/PipelineVisualizer.tsx
@@ -10,7 +10,7 @@
  * Issue: https://github.com/yangyang-how/flair2/issues/36
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useSSE, type SSEEvent } from "../lib/sse-client";
 import { Badge, ProgressBar } from "./ui";
@@ -336,6 +336,123 @@ export default function PipelineVisualizer({ runId }: PipelineVisualizerProps) {
             >
               Go now
             </a>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Activity log — collapsible */}
+      <ActivityLog events={events} />
+    </div>
+  );
+}
+
+// ── Activity Log ─────────────────────────────────────────
+
+function formatEventLabel(evt: SSEEvent): { label: string; detail: string; color: string } {
+  const d = evt.data as Record<string, unknown>;
+  switch (evt.event) {
+    case "pipeline_started":
+      return { label: "Pipeline started", detail: `${d.total_videos} videos, ${d.total_personas} personas, top ${d.top_n}`, color: "var(--stud-a)" };
+    case "stage_started":
+      return { label: `${d.stage} started`, detail: d.total_items ? `${d.total_items} items` : "", color: "var(--color-accent)" };
+    case "s1_progress":
+      return { label: `S1 Analyze`, detail: `video ${d.video_id} (${d.completed}/${d.total})`, color: "var(--disc-a)" };
+    case "s2_complete":
+      return { label: "S2 Aggregate complete", detail: `${d.pattern_count} patterns`, color: "var(--disc-a)" };
+    case "s3_progress":
+      return { label: "S3 Generate", detail: `${d.completed}/${d.total} scripts`, color: "var(--stud-a)" };
+    case "s3_complete":
+      return { label: "S3 Generate complete", detail: `${d.script_count} scripts`, color: "var(--stud-a)" };
+    case "vote_cast":
+      return { label: `S4 Vote`, detail: `${d.persona_id} voted (${d.completed}/${d.total})`, color: "var(--eval-a)" };
+    case "s5_complete":
+      return { label: "S5 Rank complete", detail: `top ${d.top_n}`, color: "var(--eval-a)" };
+    case "s6_progress":
+      return { label: "S6 Personalize", detail: `${d.script_id} (${d.completed}/${d.total})`, color: "var(--pers-a)" };
+    case "pipeline_complete":
+      return { label: "Pipeline complete", detail: `${d.result_count ?? ""} results`, color: "var(--color-success)" };
+    case "pipeline_error":
+      return { label: "Pipeline error", detail: (d.error as string) || "Unknown error", color: "var(--color-error)" };
+    case "pipeline_recovered":
+      return { label: "Pipeline recovered", detail: `from S4 checkpoint ${d.s4_checkpoint}, ${d.remaining_personas} remaining`, color: "var(--color-warning, #f59e0b)" };
+    default:
+      return { label: evt.event, detail: JSON.stringify(d), color: "var(--color-text-muted)" };
+  }
+}
+
+function ActivityLog({ events }: { events: SSEEvent[] }) {
+  const [open, setOpen] = useState(false);
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open && logEndRef.current) {
+      logEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [events.length, open]);
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between p-3 text-left hover:bg-[var(--color-surface)] transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <svg
+            className={`h-3 w-3 text-[var(--color-text-muted)] transition-transform ${open ? "rotate-90" : ""}`}
+            viewBox="0 0 12 12"
+            fill="currentColor"
+          >
+            <path d="M4.5 2l5 4-5 4V2z" />
+          </svg>
+          <span className="font-ui text-[11px] uppercase tracking-[0.1em] text-[var(--color-text-muted)]">
+            Activity Log
+          </span>
+          <span className="font-ui text-[10px] text-[var(--color-text-muted)] opacity-60">
+            {events.length} events
+          </span>
+        </div>
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ height: 0 }}
+            animate={{ height: "auto" }}
+            exit={{ height: 0 }}
+            className="overflow-hidden"
+          >
+            <div className="max-h-64 overflow-y-auto border-t border-[var(--color-border)] bg-[var(--color-bg, #000)]/30">
+              {events.length === 0 ? (
+                <p className="p-3 text-xs text-[var(--color-text-muted)]">
+                  Waiting for events...
+                </p>
+              ) : (
+                <div className="divide-y divide-[var(--color-border)]/50">
+                  {events.map((evt, i) => {
+                    const { label, detail, color } = formatEventLabel(evt);
+                    const time = evt.timestamp
+                      ? new Date(evt.timestamp).toLocaleTimeString()
+                      : "";
+                    return (
+                      <div key={evt.id || i} className="flex items-start gap-2 px-3 py-1.5 font-mono text-[11px]">
+                        <span className="shrink-0 text-[var(--color-text-muted)] opacity-50 w-16">
+                          {time}
+                        </span>
+                        <span className="shrink-0" style={{ color }}>
+                          {label}
+                        </span>
+                        {detail && (
+                          <span className="text-[var(--color-text-muted)] truncate">
+                            {detail}
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                  <div ref={logEndRef} />
+                </div>
+              )}
+            </div>
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
Two frontend bugs that made the pipeline look like it was working when it wasn't:

**Bug 1: Fake stage completion.** When a `stage_started` event arrived, the visualizer marked ALL prior stages as "completed" — even if they never actually finished. This meant a single `stage_started` for S3 would show S1 and S2 as green checkmarks, regardless of whether any work was done.

**Fix:** stages only show "completed" when their actual completion event arrives (`s1_progress` at 100%, `s2_complete`, `s3_complete`, etc.). `stage_started` only marks the current stage as "running".

**Bug 2: No stall detection.** If workers failed silently (e.g. bad API key, crash), the UI sat indefinitely showing the last received state with no warning.

**Fix:** if no SSE events arrive for 30 seconds while connected, the UI shows:
- Status indicator changes from "Live" (green pulse) to "Stalled" (amber)
- Warning banner: "Pipeline appears stalled — Workers may be failing silently"

## Test plan
- [ ] Start pipeline with valid config → stages progress honestly, no fake completions
- [ ] Start pipeline with broken workers → stall warning appears after 30s
- [ ] Pipeline error (from PR #135) → error banner shown immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)