### PR TITLE
fix: import tasks module so Celery workers register s1_analyze_task

### DIFF
--- a/backend/app/workers/celery_app.py
+++ b/backend/app/workers/celery_app.py
@@ -14,3 +14,5 @@ celery_app.conf.update(
     task_acks_late=True,
     worker_prefetch_multiplier=1,
 )
+
+import app.workers.tasks  # noqa: E402, F401 — registers all tasks with the Celery app


### PR DESCRIPTION
## Summary
- `celery_app.py` was missing an import of `app.workers.tasks`, so the worker started successfully but discarded every incoming task with `KeyError: 'app.workers.tasks.s1_analyze_task'`
- Added `import app.workers.tasks` at the bottom of `celery_app.py` to ensure all tasks are registered on worker startup

## Root cause
Confirmed via CloudWatch logs (`/ecs/flair2-dev/worker`):
```
Received unregistered task of type 'app.workers.tasks.s1_analyze_task'.
The message has been ignored and discarded.
```
The API was queueing tasks to Redis correctly, but no worker was consuming them — pipeline runs never completed and the frontend kept polling `/api/pipeline/status` indefinitely.

## Test plan
- [ ] Rebuild and redeploy worker Docker image to ECR
- [ ] Force new ECS deployment for `flair2-dev-worker` service
- [ ] Trigger a pipeline run from the frontend
- [ ] Confirm worker logs show `[celery@...] ready.` followed by `Received task: app.workers.tasks.s1_analyze_task`
- [ ] Confirm pipeline completes all stages and `GET /api/pipeline/results/{run_id}` returns 10 scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)