### PR TITLE
perf: async Kimi, per-stage max_tokens, global concurrency cap

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,11 +23,15 @@ class Settings(BaseSettings):
     kimi_api_key: str = ""
     openai_api_key: str = ""
 
-    # Rate Limits (requests per minute)
+    # Rate Limits (requests per minute — retained for the backpressure experiment)
     gemini_rpm: int = 60
     kimi_rpm: int = 60
     openai_rpm: int = 60
     enable_rate_limiter: bool = True
+
+    # Provider concurrency caps (in-flight requests). Kimi Code docs: 30. Leave
+    # one headroom slot to avoid racing with the ceiling.
+    kimi_max_concurrency: int = 29
 
     # Datasets (local paths — will be replaced by S3 in production)
     dataset_path: str = "data/sample_videos.json"
@@ -35,8 +39,8 @@ class Settings(BaseSettings):
 
     # Pipeline Defaults
     s1_video_count: int = 100
-    s3_script_count: int = 50
-    s4_persona_count: int = 100
+    s3_script_count: int = 20
+    s4_persona_count: int = 42
     s6_top_n: int = 10
 
     # Celery (db=1 — separate from state Redis)

--- a/backend/app/infra/rate_limiter.py
+++ b/backend/app/infra/rate_limiter.py
@@ -5,6 +5,49 @@ from app.infra.redis_client import RedisClient
 from app.models.errors import RateLimitError
 
 
+class RedisSemaphore:
+    """Distributed concurrency cap backed by a Redis list of tokens.
+
+    Models providers whose limit is "at most N in-flight requests" (e.g. Kimi
+    Code: concurrency ≤ 30). One Redis list (`semaphore:{name}`) is seeded
+    once with `max_slots` sentinel tokens. `acquire()` BLPOPs a token;
+    `release()` RPUSHes one back.
+
+    Seeding is idempotent via a companion SETNX flag — only the first caller
+    fills the list. Changing `max_slots` in config requires deleting
+    `semaphore:{name}` and `semaphore:{name}:seeded` to re-seed.
+
+    A process crash between acquire and release leaks a token permanently;
+    that is an acceptable prototype trade-off (upgrade to a Lua-scripted
+    lease if it becomes a real issue).
+    """
+
+    def __init__(self, redis: RedisClient, name: str, max_slots: int):
+        self._redis = redis
+        self._name = name
+        self._key = f"semaphore:{name}"
+        self._seed_flag = f"semaphore:{name}:seeded"
+        self._max_slots = max_slots
+
+    async def _ensure_seeded(self) -> None:
+        won = await self._redis.setnx(self._seed_flag, "1")
+        if won:
+            for _ in range(self._max_slots):
+                await self._redis.rpush(self._key, "1")
+
+    async def acquire(self, timeout: int = 60) -> None:
+        await self._ensure_seeded()
+        token = await self._redis.blpop(self._key, timeout=timeout)
+        if token is None:
+            raise RateLimitError(
+                f"Semaphore {self._name} timed out after {timeout}s",
+                provider=self._name,
+            )
+
+    async def release(self) -> None:
+        await self._redis.rpush(self._key, "1")
+
+
 class TokenBucketRateLimiter:
     """Sliding-window token bucket backed by Redis INCR + TTL.
 

--- a/backend/app/models/api.py
+++ b/backend/app/models/api.py
@@ -15,8 +15,8 @@ class StartPipelineRequest(BaseModel):
     reasoning_model: str  # "kimi" | "gemini" | "openai"
     video_model: str | None = None  # "seedance" | "veo" | None
     num_videos: int = 100  # S1 video count
-    num_scripts: int = 50  # S3 script count
-    num_personas: int = 100  # S4 persona count
+    num_scripts: int = 20  # S3 script count
+    num_personas: int = 42  # S4 persona count
     top_n: int = 10  # S5/S6 top N scripts
 
 

--- a/backend/app/models/pipeline.py
+++ b/backend/app/models/pipeline.py
@@ -24,8 +24,8 @@ class PipelineConfig(BaseModel):
     video_model: str | None = None
     creator_profile: CreatorProfile
     num_videos: int = 100
-    num_scripts: int = 50
-    num_personas: int = 100
+    num_scripts: int = 20
+    num_personas: int = 42
     top_n: int = 10
 
 

--- a/backend/app/pipeline/stages/s1_analyze.py
+++ b/backend/app/pipeline/stages/s1_analyze.py
@@ -21,7 +21,7 @@ async def s1_analyze(video: VideoInput, provider: ReasoningProvider) -> S1Patter
     )
 
     try:
-        response = await provider.generate_text(prompt, schema=S1Pattern)
+        response = await provider.generate_text(prompt, schema=S1Pattern, max_tokens=2048)
         data = json.loads(response)
         # Ensure video_id matches input (LLM may hallucinate a different one)
         data["video_id"] = video.video_id

--- a/backend/app/pipeline/stages/s3_generate.py
+++ b/backend/app/pipeline/stages/s3_generate.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager, nullcontext
 
 import structlog
 
@@ -53,7 +54,7 @@ async def s3_generate(
     provider: ReasoningProvider,
     feedback: list[VideoPerformance] | None = None,
     num_scripts: int | None = None,
-    acquire_token: Callable[[], Awaitable[None]] | None = None,
+    slot_factory: Callable[[], AbstractAsyncContextManager[None]] | None = None,
 ) -> list[CandidateScript]:
     """Generate candidate scripts concurrently, one LLM call per script."""
     target = num_scripts or settings.s3_script_count
@@ -67,16 +68,18 @@ async def s3_generate(
             pattern_library_summary=library_summary,
             feedback_section=feedback_section,
         )
-        if acquire_token is not None:
-            await acquire_token()
-        try:
-            response = await provider.generate_text(prompt, schema=CandidateScript)
-            data = json.loads(response)
-            data["script_id"] = str(uuid.uuid4())[:8]
-            return CandidateScript(**data)
-        except Exception as e:
-            logger.warning("s3_script_failed", error=str(e), pattern=pattern.pattern_type)
-            return None
+        slot = slot_factory() if slot_factory is not None else nullcontext()
+        async with slot:
+            try:
+                response = await provider.generate_text(
+                    prompt, schema=CandidateScript, max_tokens=2048
+                )
+                data = json.loads(response)
+                data["script_id"] = str(uuid.uuid4())[:8]
+                return CandidateScript(**data)
+            except Exception as e:
+                logger.warning("s3_script_failed", error=str(e), pattern=pattern.pattern_type)
+                return None
 
     results = await asyncio.gather(*[_generate_one(p) for p in assignments])
     scripts = [r for r in results if r is not None]

--- a/backend/app/pipeline/stages/s4_vote.py
+++ b/backend/app/pipeline/stages/s4_vote.py
@@ -80,7 +80,7 @@ async def s4_vote(
     )
 
     try:
-        response = await provider.generate_text(prompt, schema=PersonaVote)
+        response = await provider.generate_text(prompt, schema=PersonaVote, max_tokens=1024)
         data = json.loads(response)
         data["persona_id"] = persona_id
         return PersonaVote(**data)

--- a/backend/app/pipeline/stages/s6_personalize.py
+++ b/backend/app/pipeline/stages/s6_personalize.py
@@ -59,7 +59,7 @@ async def s6_personalize(
     )
 
     try:
-        response = await provider.generate_text(prompt, schema=S6Response)
+        response = await provider.generate_text(prompt, schema=S6Response, max_tokens=2048)
         data = json.loads(response)
 
         # LLM sometimes returns video_prompt as a nested object instead of string

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -12,6 +12,7 @@ class ReasoningProvider(Protocol):
         self,
         prompt: str,
         schema: type[BaseModel] | None = None,
+        max_tokens: int | None = None,
     ) -> str: ...
 
     async def analyze_content(

--- a/backend/app/providers/gemini.py
+++ b/backend/app/providers/gemini.py
@@ -34,14 +34,17 @@ class GeminiProvider:
         self,
         prompt: str,
         schema: type[BaseModel] | None = None,
+        max_tokens: int | None = None,
     ) -> str:
         client = self._get_client()
+        config = {"max_output_tokens": max_tokens} if max_tokens else None
         for attempt in range(MAX_RETRIES):
             try:
                 response = await asyncio.to_thread(
                     client.models.generate_content,
                     model=self._model,
                     contents=prompt,
+                    config=config,
                 )
                 # Capture token usage
                 if hasattr(response, "usage_metadata") and response.usage_metadata:

--- a/backend/app/providers/kimi.py
+++ b/backend/app/providers/kimi.py
@@ -18,6 +18,7 @@ MAX_RETRIES = 3
 KIMI_BASE_URL = "https://api.kimi.com/coding/v1"
 KIMI_MODEL = "kimi-k2.5"
 KIMI_USER_AGENT = "claude-code/0.1.0"
+DEFAULT_MAX_TOKENS = 4096
 
 
 class KimiProvider:
@@ -31,9 +32,9 @@ class KimiProvider:
 
     def _get_client(self):
         if self._client is None:
-            from openai import OpenAI
+            from openai import AsyncOpenAI
 
-            self._client = OpenAI(
+            self._client = AsyncOpenAI(
                 api_key=self._api_key,
                 base_url=KIMI_BASE_URL,
                 default_headers={"User-Agent": KIMI_USER_AGENT},
@@ -45,15 +46,16 @@ class KimiProvider:
         self,
         prompt: str,
         schema: type[BaseModel] | None = None,
+        max_tokens: int | None = None,
     ) -> str:
         client = self._get_client()
+        token_budget = max_tokens or DEFAULT_MAX_TOKENS
         for attempt in range(MAX_RETRIES):
             try:
-                response = await asyncio.to_thread(
-                    client.chat.completions.create,
+                response = await client.chat.completions.create(
                     model=self._model,
                     messages=[{"role": "user", "content": prompt}],
-                    max_tokens=32768,
+                    max_tokens=token_budget,
                 )
                 text = response.choices[0].message.content
 
@@ -87,24 +89,28 @@ class KimiProvider:
                 raise
             except Exception as e:
                 error_str = str(e)
+                body = getattr(e, "body", None) or getattr(e, "response", None)
+                status_code = getattr(e, "status_code", None)
                 if "429" in error_str or "rate" in error_str.lower():
+                    logger.warning(
+                        "kimi_rate_limit",
+                        attempt=attempt,
+                        status=status_code,
+                        body=str(body)[:500] if body else None,
+                        message=error_str[:500],
+                    )
                     if attempt < MAX_RETRIES - 1:
-                        logger.warning(
-                            "kimi_rate_limit",
-                            attempt=attempt,
-                            backoff=BACKOFF_SECS[attempt],
-                        )
                         await asyncio.sleep(BACKOFF_SECS[attempt])
                         continue
                     raise RateLimitError(
-                        f"Rate limited after {MAX_RETRIES} retries",
+                        f"Rate limited after {MAX_RETRIES} retries: {error_str[:200]}",
                         provider=self.name,
                         retry_after=BACKOFF_SECS[-1] * 2,
                     ) from e
                 raise ProviderError(
                     error_str,
                     provider=self.name,
-                    status_code=getattr(e, "status_code", None),
+                    status_code=status_code,
                 ) from e
 
         raise ProviderError("Unexpected retry exhaustion", provider=self.name)

--- a/backend/app/workers/tasks.py
+++ b/backend/app/workers/tasks.py
@@ -13,11 +13,13 @@ Tasks are sync; async work runs inside asyncio.run().
 
 import asyncio
 import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import structlog
 
 from app.config import settings
-from app.infra.rate_limiter import TokenBucketRateLimiter
+from app.infra.rate_limiter import RedisSemaphore, TokenBucketRateLimiter
 from app.infra.redis_client import RedisClient
 from app.models.errors import ProviderError, StageError
 from app.models.pipeline import PipelineConfig
@@ -69,14 +71,39 @@ async def _report_failure(run_id: str, stage: str, error: str) -> None:
 async def _acquire_rate_limit_token(redis: RedisClient, provider_name: str) -> None:
     """Wait for a rate-limit token before making an LLM call.
 
-    No-op when settings.enable_rate_limiter is False (useful for experiments
-    that want to compare the two modes without redeploying).
+    Kept for the backpressure experiment which still measures token-bucket
+    behavior. Production stages use `_acquire_provider_slot` instead.
     """
     if not settings.enable_rate_limiter:
         return
     rpm = getattr(settings, f"{provider_name}_rpm", 60)
     limiter = TokenBucketRateLimiter(redis, provider_name, max_tokens=rpm, window_seconds=60)
     await limiter.wait_for_token()
+
+
+@asynccontextmanager
+async def _acquire_provider_slot(
+    redis: RedisClient, provider_name: str
+) -> AsyncIterator[None]:
+    """Acquire one in-flight slot for the provider, release on exit.
+
+    Models providers whose real constraint is max concurrent requests
+    (e.g. Kimi Code ≤ 30). No-op when no `{provider}_max_concurrency`
+    setting is configured.
+    """
+    if not settings.enable_rate_limiter:
+        yield
+        return
+    max_slots = getattr(settings, f"{provider_name}_max_concurrency", None)
+    if not max_slots:
+        yield
+        return
+    sem = RedisSemaphore(redis, provider_name, max_slots=max_slots)
+    await sem.acquire()
+    try:
+        yield
+    finally:
+        await sem.release()
 
 
 # ---------------------------------------------------------------------------
@@ -100,8 +127,8 @@ def s1_analyze_task(self, run_id: str, video_json: str):
                 "description": (video.description or "")[:80],
             })
 
-            await _acquire_rate_limit_token(redis, config.reasoning_model)
-            pattern = await s1_analyze(video, provider)
+            async with _acquire_provider_slot(redis, config.reasoning_model):
+                pattern = await s1_analyze(video, provider)
             await redis.set(f"result:s1:{run_id}:{video.video_id}", pattern.model_dump_json())
 
             await orchestrator.on_s1_complete(run_id, video.video_id, pattern_summary={
@@ -175,14 +202,14 @@ def s3_generate_task(self, run_id: str):
             library = S2PatternLibrary.model_validate_json(raw)
             provider = _get_provider(config)
 
-            async def _acquire() -> None:
-                await _acquire_rate_limit_token(redis, config.reasoning_model)
+            def _slot_factory():
+                return _acquire_provider_slot(redis, config.reasoning_model)
 
             scripts = await s3_generate(
                 library,
                 provider,
                 num_scripts=config.num_scripts,
-                acquire_token=_acquire,
+                slot_factory=_slot_factory,
             )
             await redis.set(
                 f"scripts:candidates:{run_id}",
@@ -234,8 +261,8 @@ def s4_vote_task(self, run_id: str, persona_json: str):
             scripts = [CandidateScript(**s) for s in json.loads(raw)]
             provider = _get_provider(config)
 
-            await _acquire_rate_limit_token(redis, config.reasoning_model)
-            vote = await s4_vote(scripts, persona_id, provider, persona_data=persona_data)
+            async with _acquire_provider_slot(redis, config.reasoning_model):
+                vote = await s4_vote(scripts, persona_id, provider, persona_data=persona_data)
             await redis.set(f"result:s4:{run_id}:{persona_id}", vote.model_dump_json())
 
             from app.pipeline.orchestrator import Orchestrator
@@ -318,8 +345,8 @@ def s6_personalize_task(self, run_id: str, script_id: str):
             ranked = next((r for r in rankings.top_10 if r.script_id == script_id), None)
 
             provider = _get_provider(config)
-            await _acquire_rate_limit_token(redis, config.reasoning_model)
-            result = await s6_personalize(script, config.creator_profile, provider)
+            async with _acquire_provider_slot(redis, config.reasoning_model):
+                result = await s6_personalize(script, config.creator_profile, provider)
 
             if ranked is not None:
                 result.rank = ranked.rank

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -26,7 +26,7 @@ class MockReasoningProvider:
     def __init__(self):
         self.call_log: list[str] = []
 
-    async def generate_text(self, prompt: str, schema=None) -> str:
+    async def generate_text(self, prompt: str, schema=None, max_tokens=None) -> str:
         self.call_log.append(prompt[:50])
         return "Mock generated text response."
 

--- a/backend/tests/unit/test_kimi_provider.py
+++ b/backend/tests/unit/test_kimi_provider.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -40,7 +40,7 @@ class TestGenerateText:
         mock_resp = _mock_completion("Hello world")
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = MagicMock(return_value=mock_resp)
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.generate_text("Say hello")
             assert result == "Hello world"
@@ -52,7 +52,7 @@ class TestGenerateText:
         mock_resp = _mock_completion(wrapped)
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = MagicMock(return_value=mock_resp)
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.generate_text("Give JSON", schema=dict)
             parsed = json.loads(result)
@@ -63,7 +63,7 @@ class TestGenerateText:
         mock_resp = _mock_completion("text", input_tokens=50, output_tokens=100)
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = MagicMock(return_value=mock_resp)
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             await kimi_provider.generate_text("test")
             assert kimi_provider.last_usage == {"input_tokens": 50, "output_tokens": 100}
@@ -76,7 +76,7 @@ class TestRetryBehavior:
         good_resp = _mock_completion('{"valid": true}')
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = MagicMock(side_effect=[bad_resp, good_resp])
+            mock_client.chat.completions.create = AsyncMock(side_effect=[bad_resp, good_resp])
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.generate_text("Give JSON", schema=dict)
             assert json.loads(result) == {"valid": True}
@@ -89,7 +89,7 @@ class TestAnalyzeContent:
         mock_resp = _mock_completion("analysis result")
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = MagicMock(return_value=mock_resp)
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.analyze_content("video data", "analyze this")
             assert result == "analysis result"

--- a/backend/tests/unit/test_local_runner.py
+++ b/backend/tests/unit/test_local_runner.py
@@ -41,7 +41,7 @@ def smart_mock_provider():
         name = "mock"
         _script_count = 0
 
-        async def generate_text(self, prompt, schema=None):
+        async def generate_text(self, prompt, schema=None, max_tokens=None):
             prompt_lower = prompt.lower()
             if "content analyst" in prompt_lower or "what to extract" in prompt_lower:
                 return json.dumps(

--- a/backend/tests/unit/test_s1_analyze.py
+++ b/backend/tests/unit/test_s1_analyze.py
@@ -31,7 +31,7 @@ def sample_video():
 
 @pytest.mark.asyncio
 async def test_s1_analyze_returns_s1_pattern(sample_video, mock_provider):
-    async def mock_gen(prompt, schema=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None):
         return MOCK_S1_RESPONSE
 
     mock_provider.generate_text = mock_gen
@@ -43,7 +43,7 @@ async def test_s1_analyze_returns_s1_pattern(sample_video, mock_provider):
 
 @pytest.mark.asyncio
 async def test_s1_analyze_preserves_video_id(sample_video, mock_provider):
-    async def mock_gen(prompt, schema=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None):
         # Return a response with wrong video_id — stage should override
         data = json.loads(MOCK_S1_RESPONSE)
         data["video_id"] = "wrong_id"

--- a/backend/tests/unit/test_s3_generate.py
+++ b/backend/tests/unit/test_s3_generate.py
@@ -31,7 +31,7 @@ def sample_library():
 async def test_s3_generate_returns_scripts(sample_library, mock_provider):
     call_count = 0
 
-    async def mock_gen(prompt, schema=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None):
         nonlocal call_count
         call_count += 1
         return json.dumps(
@@ -55,7 +55,7 @@ async def test_s3_generate_returns_scripts(sample_library, mock_provider):
 
 @pytest.mark.asyncio
 async def test_s3_generate_assigns_unique_ids(sample_library, mock_provider):
-    async def mock_gen(prompt, schema=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None):
         return json.dumps(
             {
                 "script_id": "will_be_overridden",

--- a/backend/tests/unit/test_s4_vote.py
+++ b/backend/tests/unit/test_s4_vote.py
@@ -24,7 +24,7 @@ def sample_scripts():
 
 @pytest.mark.asyncio
 async def test_s4_vote_returns_persona_vote(sample_scripts, mock_provider):
-    async def mock_gen(prompt, schema=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None):
         return json.dumps(
             {
                 "persona_id": "persona_0",

--- a/backend/tests/unit/test_s6_personalize.py
+++ b/backend/tests/unit/test_s6_personalize.py
@@ -21,7 +21,7 @@ def sample_script():
 
 @pytest.mark.asyncio
 async def test_s6_returns_final_result(sample_script, sample_creator_profile, mock_provider):
-    async def mock_gen(prompt, schema=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None):
         return json.dumps(
             {
                 "personalized_script": "Yo what's up, so lowkey most people waste their mornings...",  # noqa: E501
@@ -40,7 +40,7 @@ async def test_s6_returns_final_result(sample_script, sample_creator_profile, mo
 
 @pytest.mark.asyncio
 async def test_s6_preserves_original_script(sample_script, sample_creator_profile, mock_provider):
-    async def mock_gen(prompt, schema=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None):
         return json.dumps(
             {
                 "personalized_script": "Rewritten version",

--- a/frontend/src/pages/create.astro
+++ b/frontend/src/pages/create.astro
@@ -200,11 +200,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           </div>
           <div>
             <label class="mb-1.5 block text-sm font-medium" for="num_scripts">Scripts to Generate</label>
-            <input id="num_scripts" name="num_scripts" type="number" min="1" value="50" class="input-field" />
+            <input id="num_scripts" name="num_scripts" type="number" min="1" value="20" class="input-field" />
           </div>
           <div>
             <label class="mb-1.5 block text-sm font-medium" for="num_personas">Personas</label>
-            <input id="num_personas" name="num_personas" type="number" min="1" value="100" class="input-field" />
+            <input id="num_personas" name="num_personas" type="number" min="1" value="42" class="input-field" />
           </div>
           <div>
             <label class="mb-1.5 block text-sm font-medium" for="top_n">Top N</label>
@@ -369,8 +369,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         reasoning_model,
         video_model: video_model_raw || null,
         num_videos: parseInt((document.getElementById("num_videos") as HTMLInputElement).value) || 100,
-        num_scripts: parseInt((document.getElementById("num_scripts") as HTMLInputElement).value) || 50,
-        num_personas: parseInt((document.getElementById("num_personas") as HTMLInputElement).value) || 100,
+        num_scripts: parseInt((document.getElementById("num_scripts") as HTMLInputElement).value) || 20,
+        num_personas: parseInt((document.getElementById("num_personas") as HTMLInputElement).value) || 42,
         top_n: parseInt((document.getElementById("top_n") as HTMLInputElement).value) || 10,
       });
 


### PR DESCRIPTION
## Why
End-to-end pipeline took ~13 min per run, with intermittent stalls and occasional 429s. Root cause is three overlapping bottlenecks in the provider/worker layer.

## What changed
1. **`KimiProvider` → `AsyncOpenAI`**. The old sync `OpenAI` client wrapped in `asyncio.to_thread` capped S3's internal `asyncio.gather` at the 6-thread default ThreadPoolExecutor, so 50 "concurrent" calls ran 6-at-a-time.
2. **Stage-specific `max_tokens`** (S1/S3/S6 = 2048, S4 = 1024). Previously hardcoded to 32768, which at Kimi's documented 100 tokens/s output speed means each call could stream for 5+ minutes. Actual output fits in ≤2k tokens everywhere.
3. **`RedisSemaphore` as a global concurrency cap** (seeded with 29 tokens, one below Kimi's documented 30 ceiling). Replaces the per-minute token bucket on the Kimi path — wrong abstraction for a connection-cap API. The token bucket class stays in `rate_limiter.py` for the backpressure experiment.
4. **Defaults**: `num_scripts` 50→20 (S5 only keeps top 10 anyway), `num_personas` 100→42 (±9% sampling SE is fine for ranking 50 scripts). Frontend form and backend models updated together.
5. Log the actual Kimi 429 response body so next time we know exactly which limit tripped.

## Comparison

| Stage | Current calls | Current time | Calls after PR | Time after PR | Speedup |
|---|---|---|---|---|---|
| S1 Analyze | 100 | ~4 min | 100 | ~2 min | 2× |
| S3 Generate | 50 | ~4 min | 20 | ~15s | 16× |
| S4 Vote | 100 | ~4 min | 42 | ~28s | ~8× |
| S6 Personalize | 10 | ~30s | 10 | ~15s | 2× |
| **End-to-end** | **260** | **~13 min** | **172** | **~3 min** | **~4.3×** |

S3 gets the biggest jump because it was doubly throttled — thread-pool-capped *and* over-allocated scripts. S4 shortens mainly from `max_tokens=1024`. Budget: 260 → 172 calls gives ~1.5× more runs per 5-hour Kimi window.

## Notes
- `RedisSemaphore` seeds via SETNX flag — idempotent across workers. Changing `kimi_max_concurrency` in config requires `DEL semaphore:kimi semaphore:kimi:seeded` to reseed.
- Process crash between `acquire` and `release` leaks one slot. Acceptable prototype trade-off; upgrade to a Lua-scripted lease if it causes real incidents.
- `kimi_rpm` / `gemini_rpm` config retained — still used by `tests/experiments/test_backpressure.py` which measures token-bucket behavior specifically.

## Test plan
- [x] `ruff check .` clean
- [x] 110 unit + integration tests pass (updated mocks to accept `max_tokens` kwarg and switched Kimi tests to `AsyncMock`)
- [ ] Deploy and run one pipeline end-to-end — confirm wall-clock ≈ 3 min and no 429s from our side
- [ ] Run two pipelines back-to-back within a 5H window — confirm budget usage ~35%

🤖 Generated with [Claude Code](https://claude.com/claude-code)