### PR TITLE
fix: switch Kimi provider to Anthropic Messages API + per-stage temperature

### DIFF
--- a/backend/app/pipeline/stages/s1_analyze.py
+++ b/backend/app/pipeline/stages/s1_analyze.py
@@ -21,7 +21,9 @@ async def s1_analyze(video: VideoInput, provider: ReasoningProvider) -> S1Patter
     )
 
     try:
-        response = await provider.generate_text(prompt, schema=S1Pattern, max_tokens=2048)
+        response = await provider.generate_text(
+            prompt, schema=S1Pattern, max_tokens=2048, temperature=0.2
+        )
         data = json.loads(response)
         # Ensure video_id matches input (LLM may hallucinate a different one)
         data["video_id"] = video.video_id

--- a/backend/app/pipeline/stages/s3_generate.py
+++ b/backend/app/pipeline/stages/s3_generate.py
@@ -72,7 +72,7 @@ async def s3_generate(
         async with slot:
             try:
                 response = await provider.generate_text(
-                    prompt, schema=CandidateScript, max_tokens=2048
+                    prompt, schema=CandidateScript, max_tokens=2048, temperature=0.9
                 )
                 data = json.loads(response)
                 data["script_id"] = str(uuid.uuid4())[:8]

--- a/backend/app/pipeline/stages/s4_vote.py
+++ b/backend/app/pipeline/stages/s4_vote.py
@@ -80,7 +80,9 @@ async def s4_vote(
     )
 
     try:
-        response = await provider.generate_text(prompt, schema=PersonaVote, max_tokens=1024)
+        response = await provider.generate_text(
+            prompt, schema=PersonaVote, max_tokens=1024, temperature=0.6
+        )
         data = json.loads(response)
         data["persona_id"] = persona_id
         return PersonaVote(**data)

--- a/backend/app/pipeline/stages/s6_personalize.py
+++ b/backend/app/pipeline/stages/s6_personalize.py
@@ -59,7 +59,9 @@ async def s6_personalize(
     )
 
     try:
-        response = await provider.generate_text(prompt, schema=S6Response, max_tokens=2048)
+        response = await provider.generate_text(
+            prompt, schema=S6Response, max_tokens=2048, temperature=0.7
+        )
         data = json.loads(response)
 
         # LLM sometimes returns video_prompt as a nested object instead of string

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -13,6 +13,7 @@ class ReasoningProvider(Protocol):
         prompt: str,
         schema: type[BaseModel] | None = None,
         max_tokens: int | None = None,
+        temperature: float | None = None,
     ) -> str: ...
 
     async def analyze_content(

--- a/backend/app/providers/gemini.py
+++ b/backend/app/providers/gemini.py
@@ -35,9 +35,16 @@ class GeminiProvider:
         prompt: str,
         schema: type[BaseModel] | None = None,
         max_tokens: int | None = None,
+        temperature: float | None = None,
     ) -> str:
         client = self._get_client()
-        config = {"max_output_tokens": max_tokens} if max_tokens else None
+        config: dict | None = None
+        if max_tokens or temperature is not None:
+            config = {}
+            if max_tokens:
+                config["max_output_tokens"] = max_tokens
+            if temperature is not None:
+                config["temperature"] = temperature
         for attempt in range(MAX_RETRIES):
             try:
                 response = await asyncio.to_thread(

--- a/backend/app/providers/kimi.py
+++ b/backend/app/providers/kimi.py
@@ -1,4 +1,10 @@
-"""Kimi (Moonshot AI) reasoning provider via OpenAI-compatible API."""
+"""Kimi (Moonshot AI) reasoning provider via the Anthropic Messages API.
+
+Kimi's coding endpoint migrated to an Anthropic-compatible schema
+(see /coding/v1/messages). The legacy OpenAI /chat/completions shim
+now returns a misleading "only 0.6 is allowed for this model" error
+for every request, regardless of temperature — a dead surface.
+"""
 
 import asyncio
 import json
@@ -15,8 +21,9 @@ logger = structlog.get_logger()
 BACKOFF_SECS = [1, 2, 4]
 MAX_RETRIES = 3
 
-KIMI_BASE_URL = "https://api.kimi.com/coding/v1"
-KIMI_MODEL = "kimi-k2.5"
+# Anthropic SDK appends /v1/messages; base_url stops before that.
+KIMI_BASE_URL = "https://api.kimi.com/coding"
+KIMI_MODEL = "kimi-for-coding"
 KIMI_USER_AGENT = "claude-code/0.1.0"
 DEFAULT_MAX_TOKENS = 4096
 
@@ -32,9 +39,9 @@ class KimiProvider:
 
     def _get_client(self):
         if self._client is None:
-            from openai import AsyncOpenAI
+            from anthropic import AsyncAnthropic
 
-            self._client = AsyncOpenAI(
+            self._client = AsyncAnthropic(
                 api_key=self._api_key,
                 base_url=KIMI_BASE_URL,
                 default_headers={"User-Agent": KIMI_USER_AGENT},
@@ -47,22 +54,27 @@ class KimiProvider:
         prompt: str,
         schema: type[BaseModel] | None = None,
         max_tokens: int | None = None,
+        temperature: float | None = None,
     ) -> str:
         client = self._get_client()
         token_budget = max_tokens or DEFAULT_MAX_TOKENS
+        kwargs: dict = {
+            "model": self._model,
+            "max_tokens": token_budget,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+
         for attempt in range(MAX_RETRIES):
             try:
-                response = await client.chat.completions.create(
-                    model=self._model,
-                    messages=[{"role": "user", "content": prompt}],
-                    max_tokens=token_budget,
-                )
-                text = response.choices[0].message.content
+                response = await client.messages.create(**kwargs)
+                text = _extract_text(response)
 
                 if response.usage:
                     self.last_usage = {
-                        "input_tokens": response.usage.prompt_tokens,
-                        "output_tokens": response.usage.completion_tokens,
+                        "input_tokens": response.usage.input_tokens,
+                        "output_tokens": response.usage.output_tokens,
                     }
 
                 if schema:
@@ -72,9 +84,7 @@ class KimiProvider:
                     except json.JSONDecodeError as e:
                         if attempt < MAX_RETRIES - 1:
                             logger.warning(
-                                "kimi_invalid_json",
-                                attempt=attempt,
-                                error=str(e),
+                                "kimi_invalid_json", attempt=attempt, error=str(e)
                             )
                             continue
                         raise InvalidResponseError(
@@ -118,3 +128,17 @@ class KimiProvider:
     async def analyze_content(self, content: str, prompt: str) -> str:
         full_prompt = f"{prompt}\n\nContent to analyze:\n{content}"
         return await self.generate_text(full_prompt)
+
+
+def _extract_text(response) -> str:
+    """Flatten Anthropic Message.content blocks into a single string.
+
+    response.content is a list of content blocks; text blocks have a `text`
+    attribute. Tool-use blocks and other types are ignored for now.
+    """
+    parts: list[str] = []
+    for block in response.content:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    return "".join(parts)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "structlog>=24.1",
     "python-dotenv>=1.0",
     "openai>=1.0",
+    "anthropic>=0.40",
     "redis[hiredis]>=5.0",
     "celery>=5.3",
     "boto3>=1.34",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -26,7 +26,9 @@ class MockReasoningProvider:
     def __init__(self):
         self.call_log: list[str] = []
 
-    async def generate_text(self, prompt: str, schema=None, max_tokens=None) -> str:
+    async def generate_text(
+        self, prompt: str, schema=None, max_tokens=None, temperature=None
+    ) -> str:
         self.call_log.append(prompt[:50])
         return "Mock generated text response."
 

--- a/backend/tests/unit/test_kimi_provider.py
+++ b/backend/tests/unit/test_kimi_provider.py
@@ -11,14 +11,15 @@ def kimi_provider():
     return KimiProvider(api_key="sk-kimi-test-key")
 
 
-def _mock_completion(content: str, input_tokens: int = 10, output_tokens: int = 20):
-    """Build a mock ChatCompletion response."""
-    mock = MagicMock()
-    mock.choices = [MagicMock()]
-    mock.choices[0].message.content = content
-    mock.usage.prompt_tokens = input_tokens
-    mock.usage.completion_tokens = output_tokens
-    return mock
+def _mock_message(text: str, input_tokens: int = 10, output_tokens: int = 20):
+    """Build a mock Anthropic Message response."""
+    msg = MagicMock()
+    block = MagicMock()
+    block.text = text
+    msg.content = [block]
+    msg.usage.input_tokens = input_tokens
+    msg.usage.output_tokens = output_tokens
+    return msg
 
 
 class TestKimiProviderProtocol:
@@ -37,10 +38,10 @@ class TestKimiProviderProtocol:
 class TestGenerateText:
     @pytest.mark.asyncio
     async def test_returns_text(self, kimi_provider):
-        mock_resp = _mock_completion("Hello world")
+        mock_resp = _mock_message("Hello world")
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+            mock_client.messages.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.generate_text("Say hello")
             assert result == "Hello world"
@@ -49,10 +50,10 @@ class TestGenerateText:
     async def test_extracts_json_when_schema(self, kimi_provider):
         json_str = json.dumps({"key": "value"})
         wrapped = f"```json\n{json_str}\n```"
-        mock_resp = _mock_completion(wrapped)
+        mock_resp = _mock_message(wrapped)
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+            mock_client.messages.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.generate_text("Give JSON", schema=dict)
             parsed = json.loads(result)
@@ -60,40 +61,62 @@ class TestGenerateText:
 
     @pytest.mark.asyncio
     async def test_returns_token_usage(self, kimi_provider):
-        mock_resp = _mock_completion("text", input_tokens=50, output_tokens=100)
+        mock_resp = _mock_message("text", input_tokens=50, output_tokens=100)
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+            mock_client.messages.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             await kimi_provider.generate_text("test")
             assert kimi_provider.last_usage == {"input_tokens": 50, "output_tokens": 100}
+
+    @pytest.mark.asyncio
+    async def test_passes_temperature_when_specified(self, kimi_provider):
+        mock_resp = _mock_message("ok")
+        with patch.object(kimi_provider, "_get_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_resp)
+            mock_client_fn.return_value = mock_client
+            await kimi_provider.generate_text("test", temperature=0.2)
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert call_kwargs["temperature"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_omits_temperature_when_none(self, kimi_provider):
+        mock_resp = _mock_message("ok")
+        with patch.object(kimi_provider, "_get_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=mock_resp)
+            mock_client_fn.return_value = mock_client
+            await kimi_provider.generate_text("test")
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert "temperature" not in call_kwargs
 
 
 class TestRetryBehavior:
     @pytest.mark.asyncio
     async def test_retries_on_invalid_json(self, kimi_provider):
-        bad_resp = _mock_completion("not json")
-        good_resp = _mock_completion('{"valid": true}')
+        bad_resp = _mock_message("not json")
+        good_resp = _mock_message('{"valid": true}')
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = AsyncMock(side_effect=[bad_resp, good_resp])
+            mock_client.messages.create = AsyncMock(side_effect=[bad_resp, good_resp])
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.generate_text("Give JSON", schema=dict)
             assert json.loads(result) == {"valid": True}
-            assert mock_client.chat.completions.create.call_count == 2
+            assert mock_client.messages.create.call_count == 2
 
 
 class TestAnalyzeContent:
     @pytest.mark.asyncio
     async def test_combines_content_and_prompt(self, kimi_provider):
-        mock_resp = _mock_completion("analysis result")
+        mock_resp = _mock_message("analysis result")
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
-            mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+            mock_client.messages.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
             result = await kimi_provider.analyze_content("video data", "analyze this")
             assert result == "analysis result"
-            call_args = mock_client.chat.completions.create.call_args
+            call_args = mock_client.messages.create.call_args
             messages = call_args[1]["messages"]
             user_msg = messages[-1]["content"]
             assert "video data" in user_msg

--- a/backend/tests/unit/test_local_runner.py
+++ b/backend/tests/unit/test_local_runner.py
@@ -41,7 +41,9 @@ def smart_mock_provider():
         name = "mock"
         _script_count = 0
 
-        async def generate_text(self, prompt, schema=None, max_tokens=None):
+        async def generate_text(
+            self, prompt, schema=None, max_tokens=None, temperature=None
+        ):
             prompt_lower = prompt.lower()
             if "content analyst" in prompt_lower or "what to extract" in prompt_lower:
                 return json.dumps(

--- a/backend/tests/unit/test_s1_analyze.py
+++ b/backend/tests/unit/test_s1_analyze.py
@@ -31,7 +31,7 @@ def sample_video():
 
 @pytest.mark.asyncio
 async def test_s1_analyze_returns_s1_pattern(sample_video, mock_provider):
-    async def mock_gen(prompt, schema=None, max_tokens=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None, temperature=None):
         return MOCK_S1_RESPONSE
 
     mock_provider.generate_text = mock_gen
@@ -43,7 +43,7 @@ async def test_s1_analyze_returns_s1_pattern(sample_video, mock_provider):
 
 @pytest.mark.asyncio
 async def test_s1_analyze_preserves_video_id(sample_video, mock_provider):
-    async def mock_gen(prompt, schema=None, max_tokens=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None, temperature=None):
         # Return a response with wrong video_id — stage should override
         data = json.loads(MOCK_S1_RESPONSE)
         data["video_id"] = "wrong_id"

--- a/backend/tests/unit/test_s3_generate.py
+++ b/backend/tests/unit/test_s3_generate.py
@@ -31,7 +31,7 @@ def sample_library():
 async def test_s3_generate_returns_scripts(sample_library, mock_provider):
     call_count = 0
 
-    async def mock_gen(prompt, schema=None, max_tokens=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None, temperature=None):
         nonlocal call_count
         call_count += 1
         return json.dumps(
@@ -55,7 +55,7 @@ async def test_s3_generate_returns_scripts(sample_library, mock_provider):
 
 @pytest.mark.asyncio
 async def test_s3_generate_assigns_unique_ids(sample_library, mock_provider):
-    async def mock_gen(prompt, schema=None, max_tokens=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None, temperature=None):
         return json.dumps(
             {
                 "script_id": "will_be_overridden",

--- a/backend/tests/unit/test_s4_vote.py
+++ b/backend/tests/unit/test_s4_vote.py
@@ -24,7 +24,7 @@ def sample_scripts():
 
 @pytest.mark.asyncio
 async def test_s4_vote_returns_persona_vote(sample_scripts, mock_provider):
-    async def mock_gen(prompt, schema=None, max_tokens=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None, temperature=None):
         return json.dumps(
             {
                 "persona_id": "persona_0",

--- a/backend/tests/unit/test_s6_personalize.py
+++ b/backend/tests/unit/test_s6_personalize.py
@@ -21,7 +21,7 @@ def sample_script():
 
 @pytest.mark.asyncio
 async def test_s6_returns_final_result(sample_script, sample_creator_profile, mock_provider):
-    async def mock_gen(prompt, schema=None, max_tokens=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None, temperature=None):
         return json.dumps(
             {
                 "personalized_script": "Yo what's up, so lowkey most people waste their mornings...",  # noqa: E501
@@ -40,7 +40,7 @@ async def test_s6_returns_final_result(sample_script, sample_creator_profile, mo
 
 @pytest.mark.asyncio
 async def test_s6_preserves_original_script(sample_script, sample_creator_profile, mock_provider):
-    async def mock_gen(prompt, schema=None, max_tokens=None):
+    async def mock_gen(prompt, schema=None, max_tokens=None, temperature=None):
         return json.dumps(
             {
                 "personalized_script": "Rewritten version",


### PR DESCRIPTION
## What broke

Every Kimi call today returned **400 "invalid temperature: only 0.6 is allowed for this model"** — even when we sent exactly `0.6`, even when we sent no temperature at all. The error message is a red herring.

## What's actually going on

Kimi Code's coding endpoint migrated to an **Anthropic Messages-compatible schema** at `/coding/v1/messages`. The legacy OpenAI `/chat/completions` shim we were using throws that misleading error for every shape of request now — it's a dying surface.

Probing with curl confirmed:

| Endpoint + body | Result |
|---|---|
| `POST /coding/v1/chat/completions` (any temp, any model, any param combo) | **400 "only 0.6 is allowed"** |
| `POST /coding/v1/messages` with t=0.0–1.0 | **works** |
| `POST /coding/v1/messages` with t=1.5 | clean 400 `"temperature must not be greater than 1.000000"` |
| `GET /coding/v1/models` | Advertises one canonical model: `kimi-for-coding` (display name `k2.6`, `supports_reasoning: true`) |

## Fix

Rewrite `KimiProvider` against `AsyncAnthropic` with `base_url=https://api.kimi.com/coding` (the SDK appends `/v1/messages`). Preserves:

- User-Agent whitelist workaround (`claude-code/0.1.0`)
- `MAX_RETRIES=3` with exponential backoff
- Schema-based JSON extraction + retry on invalid JSON
- Usage tracking (Anthropic's `input_tokens` / `output_tokens`)

Model ID changes from `kimi-k2.5` → `kimi-for-coding` (the only one Kimi actually serves).

Also adds `anthropic>=0.40` to `backend/pyproject.toml`.

## Per-stage temperature

Now that temperature actually works, thread it through the provider interface (same shape as `max_tokens`) and set values matching each stage's task character:

| Stage | Temp | Why |
|---|---|---|
| **S1 Analyze** | 0.2 | Classification — same video should extract the same pattern on rerun; high temp pollutes S2's frequency counts |
| **S3 Generate** | 0.9 | Creative writing — want 20 distinct scripts, not 20 near-duplicates |
| **S4 Vote** | 0.6 | Balanced judgment — consistent per-persona taste, but enough variation across 42 voters to avoid groupthink |
| **S6 Personalize** | 0.7 | Constrained creative rewrite — tethered to creator's vocabulary/tone |

## Verified

- [x] `ruff check .` clean
- [x] **112 tests pass** (updated mocks to accept `temperature`; rewrote Kimi tests to `AsyncMock` the `messages.create` call with Anthropic response shape; added 2 new tests confirming temperature is passed through or omitted correctly)
- [x] **Live round-trip** through the rewritten `KimiProvider` against the real endpoint:
  - plain text `t=0.2` → returns, usage captured
  - JSON schema `t=0.6` → returns valid JSON, extracted correctly
  - no temp → server default, works
- [ ] After deploy: confirm a pipeline run completes end-to-end with no more "only 0.6 is allowed" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)