### PR TITLE
feat: RUNS tab lists previous pipeline runs + fix uv.lock drift

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -33,6 +33,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.96.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -524,6 +543,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "fakeredis"
 version = "2.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -566,6 +594,7 @@ name = "flair2"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "boto3" },
     { name = "celery" },
     { name = "fastapi" },
@@ -597,6 +626,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.40" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "celery", specifier = ">=5.3" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.21" },

--- a/frontend/src/components/RunsList.tsx
+++ b/frontend/src/components/RunsList.tsx
@@ -1,0 +1,117 @@
+/**
+ * Runs List — shows previous pipeline runs for the current session.
+ *
+ * Uses /api/runs; entries link to /pipeline/?id=... (live/failed) or
+ * /results/... (completed).
+ */
+
+import { useEffect, useState } from "react";
+import { listRuns, type RunStatus } from "../lib/api-client";
+
+function statusColor(status: string): string {
+  switch (status) {
+    case "completed":
+      return "var(--color-success)";
+    case "failed":
+      return "var(--color-error)";
+    case "running":
+      return "var(--disc-a)";
+    default:
+      return "var(--color-text-muted)";
+  }
+}
+
+function linkFor(run: RunStatus): string {
+  if (run.status === "completed") return `/results/${run.run_id}`;
+  return `/pipeline/?id=${run.run_id}`;
+}
+
+export default function RunsList() {
+  const [runs, setRuns] = useState<RunStatus[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await listRuns();
+        if (!cancelled) setRuns(resp.runs);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <p className="font-ui text-sm text-[var(--color-error)]">
+        Failed to load runs: {error}
+      </p>
+    );
+  }
+
+  if (runs === null) {
+    return (
+      <p className="font-ui text-sm text-[var(--color-text-muted)]">Loading…</p>
+    );
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="space-y-2">
+        <p className="font-ui text-sm text-[var(--color-text-muted)]">
+          No runs yet for this session.
+        </p>
+        <a
+          href="/create"
+          className="font-ui text-[11px] uppercase tracking-[0.1em] text-[var(--stud-b)] hover:underline"
+        >
+          Start a campaign →
+        </a>
+      </div>
+    );
+  }
+
+  // Newest-first display. Backend returns in rpush order, so reverse for newest-first.
+  const ordered = [...runs].reverse();
+
+  return (
+    <ul className="divide-y divide-[var(--color-border)] rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+      {ordered.map((run) => (
+        <li key={run.run_id}>
+          <a
+            href={linkFor(run)}
+            className="flex items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-[var(--color-bg)]/50"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: statusColor(run.status) }}
+                aria-label={run.status}
+              />
+              <span className="font-mono text-sm text-[var(--color-text)] truncate">
+                {run.run_id}
+              </span>
+            </div>
+            <div className="flex items-center gap-4 shrink-0">
+              {run.current_stage && run.status === "running" && (
+                <span className="font-mono text-[10px] text-[var(--color-text-muted)]">
+                  at {run.current_stage}
+                </span>
+              )}
+              <span
+                className="font-ui text-[10px] uppercase tracking-[0.14em]"
+                style={{ color: statusColor(run.status) }}
+              >
+                {run.status}
+              </span>
+            </div>
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/pages/runs.astro
+++ b/frontend/src/pages/runs.astro
@@ -1,0 +1,18 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import RunsList from "../components/RunsList";
+---
+
+<BaseLayout title="Runs">
+  <div class="mx-auto max-w-3xl">
+    <div class="mb-6">
+      <h1 class="font-display text-[clamp(28px,5vw,48px)] tracking-[0.06em]">
+        Runs
+      </h1>
+      <p class="font-ui mt-2 text-sm text-[var(--color-text-muted)]">
+        Previous pipeline runs for this session.
+      </p>
+    </div>
+    <RunsList client:load />
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## The bug
Nav had a **Runs** link pointing at \`/runs\` but no page existed — 404. You asked for it to work.

The backend \`/api/runs\` endpoint already returns the session's run list, so this is purely frontend wiring.

## What the page shows
Newest-first list. Each row is a link:
- Colored dot: green (completed), red (failed), orange-ish (running), muted (pending)
- Truncated \`run_id\` in mono font
- Current stage (for in-flight runs only, e.g. "at S3_SEQUENTIAL")
- Status badge

Clicking:
- **completed** → \`/results/{id}\`
- **running / failed / pending** → \`/pipeline/?id={id}\` so the live visualizer + stall banner still work

Empty-state renders a "Start a campaign →" link.

## Bonus: uv.lock refresh
When #146 (added \`anthropic\` to \`pyproject.toml\`) and #147 (added \`uv.lock\`) merged, #146 landed after #147's lock was generated — so main's lockfile is currently missing \`anthropic\`. \`uv sync --frozen\` on a clean clone would fail. This PR regenerates the lockfile; `Resolved 97 packages` (was 95), only anthropic + its transitive deps added.

## Not in scope
- INSIGHTS tab stays a stub (you said you don't care for now)
- Enriching runs with timestamps / creator-tone hints / result counts — `list_runs` would need backend changes to persist `created_at`; can follow up
- Deleting old runs — no lifecycle UI yet

## Test plan
- [x] \`astro check\` — 0 errors
- [x] \`uv sync --frozen\` succeeds in a clean venv after the lockfile refresh
- [ ] After deploy: click **Runs** in nav → list of today's runs appears
- [ ] Clicking a completed run → results page
- [ ] Clicking a running run → live pipeline page
- [ ] New session (different cookie) → empty-state renders with "Start a campaign →" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)