### PR TITLE
feat: S4 matrix — rank gradient, Borda tally, persona bio sidebar

### DIFF
--- a/backend/app/workers/tasks.py
+++ b/backend/app/workers/tasks.py
@@ -251,6 +251,8 @@ def s4_vote_task(self, run_id: str, persona_json: str):
 
             persona_name = persona_data.get("name") or persona_id
             persona_location = persona_data.get("location")
+            persona_age = persona_data.get("age")
+            persona_occupation = persona_data.get("occupation")
 
             existing = await redis.get(f"result:s4:{run_id}:{persona_id}")
             if existing is not None:
@@ -272,6 +274,8 @@ def s4_vote_task(self, run_id: str, persona_json: str):
                 "persona_id": persona_id,
                 "name": persona_name,
                 "location": persona_location,
+                "age": persona_age,
+                "occupation": persona_occupation,
             })
 
             async with _acquire_provider_slot(redis, config.reasoning_model):

--- a/frontend/src/components/S4VoteMatrix.tsx
+++ b/frontend/src/components/S4VoteMatrix.tsx
@@ -1,29 +1,55 @@
 /**
- * S4 Vote Matrix — 20 scripts × 42 voters matrix showing concurrent evaluation.
+ * S4 Vote Matrix — 20 scripts × 42 voters matrix.
  *
  * Cell states:
  *   blank  — voter hasn't started yet
- *   green  — voter picked this script (one of their top-5)
+ *   green gradient — voter picked this script. Darker green = higher
+ *     rank (the order inside the voter's top-5 matters; see S5 scoring).
  *   grey   — voter voted but did NOT pick this script
  *
- * Bottom row: running vote count per script (0–N voters).
+ * Bottom row: weighted Borda score per script (rank-1 = 5pts … rank-5 =
+ * 1pt). Matches S5's aggregation, so the tall columns are literally the
+ * scripts that are going to win.
  */
 
 import { useMemo } from "react";
 import type { SSEEvent } from "../lib/sse-client";
 
+// S5 weights: rank-1 = 5pts through rank-5 = 1pt.
+const BORDA_WEIGHTS = [5, 4, 3, 2, 1];
+
+// 5 shades of green for rank 1 → 5. Rank-1 is the darkest; rank-5 is lightest.
+// Picked by eye to stay legible on the light-lavender background.
+const RANK_SHADES = [
+  "#0F766E", // rank 1 — teal-700
+  "#14B8A6", // rank 2 — teal-500
+  "#5EEAD4", // rank 3 — teal-300
+  "#99F6E4", // rank 4 — teal-200
+  "#CCFBF1", // rank 5 — teal-100
+];
+
 interface VoterRow {
   personaId: string;
   displayName: string;
   location?: string;
+  age?: number;
+  occupation?: string;
   state: "pending" | "voting" | "voted";
-  picks: Set<string>;
+  /** map from script_id → rank (0-indexed, 0 = voter's #1 pick) */
+  ranks: Record<string, number>;
 }
 
 function firstName(name: string | undefined, personaId: string): string {
   if (!name || name === personaId) return personaId.replace("persona_", "#");
   const parts = name.split(" ");
-  return parts[0].length <= 12 ? parts[0] : parts[0].slice(0, 11) + "…";
+  return parts[0].length <= 14 ? parts[0] : parts[0].slice(0, 13) + "…";
+}
+
+function country(location?: string): string {
+  if (!location) return "";
+  // Entries look like "São Paulo, Brazil" — last segment is the country.
+  const parts = location.split(",").map((p) => p.trim());
+  return parts[parts.length - 1] || "";
 }
 
 function deriveMatrix(
@@ -48,8 +74,10 @@ function deriveMatrix(
         personaId: pid,
         displayName: firstName(d.name as string | undefined, pid),
         location: (d.location as string) || undefined,
+        age: (d.age as number) || undefined,
+        occupation: (d.occupation as string) || undefined,
         state: "voting",
-        picks: new Set(),
+        ranks: {},
       });
     }
 
@@ -58,6 +86,10 @@ function deriveMatrix(
       if (!rowsByPersona.has(pid)) order.push(pid);
       const existing = rowsByPersona.get(pid);
       const top5 = (d.top_5 as string[] | undefined) || [];
+      const ranks: Record<string, number> = {};
+      top5.forEach((sid, i) => {
+        ranks[sid] = i;
+      });
       rowsByPersona.set(pid, {
         personaId: pid,
         displayName: firstName(
@@ -65,13 +97,14 @@ function deriveMatrix(
           pid,
         ),
         location: existing?.location,
+        age: existing?.age,
+        occupation: existing?.occupation,
         state: "voted",
-        picks: new Set(top5),
+        ranks,
       });
     }
   }
 
-  // Reserve all 42 rows — pending rows appear blank until their voter starts.
   const rows: VoterRow[] = [];
   for (let i = 0; i < totalPersonas; i++) {
     if (i < order.length) {
@@ -81,7 +114,7 @@ function deriveMatrix(
         personaId: `pending_${i}`,
         displayName: `${i + 1}`,
         state: "pending",
-        picks: new Set(),
+        ranks: {},
       });
     }
   }
@@ -100,7 +133,6 @@ export default function S4VoteMatrix({ events, totalPersonas }: S4VoteMatrixProp
     [events, totalPersonas],
   );
 
-  // If we don't know the script axis yet, show a placeholder.
   if (scriptIds.length === 0) {
     return (
       <div className="text-[11px] font-mono text-[var(--color-text-muted)]">
@@ -109,16 +141,24 @@ export default function S4VoteMatrix({ events, totalPersonas }: S4VoteMatrixProp
     );
   }
 
-  const columnVoteCounts: number[] = scriptIds.map((sid) =>
-    rows.reduce((n, r) => n + (r.picks.has(sid) ? 1 : 0), 0),
+  // Borda totals per column (matches S5 aggregation).
+  const columnBorda: number[] = scriptIds.map((sid) =>
+    rows.reduce((sum, r) => {
+      const rank = r.ranks[sid];
+      if (rank === undefined || rank < 0 || rank >= BORDA_WEIGHTS.length) return sum;
+      return sum + BORDA_WEIGHTS[rank];
+    }, 0),
   );
-  const maxVotes = Math.max(1, ...columnVoteCounts);
+  const columnVoteCounts: number[] = scriptIds.map((sid) =>
+    rows.reduce((n, r) => n + (r.ranks[sid] !== undefined ? 1 : 0), 0),
+  );
+  const maxBorda = Math.max(1, ...columnBorda);
 
   const votedRows = rows.filter((r) => r.state === "voted").length;
   const votingRows = rows.filter((r) => r.state === "voting").length;
 
-  const CELL = 22; // px — cell width & height
-  const NAME_W = 96; // px — left sidebar width
+  const CELL = 22;
+  const NAME_W = 180;
 
   return (
     <div className="space-y-3">
@@ -142,10 +182,27 @@ export default function S4VoteMatrix({ events, totalPersonas }: S4VoteMatrixProp
         )}
       </div>
 
-      {/* Matrix — scrolls horizontally if viewport narrower than content */}
+      {/* Rank legend */}
+      <div className="flex items-center gap-3 text-[10px] font-mono text-[var(--color-text-muted)]">
+        <span>Rank in voter's top 5:</span>
+        {RANK_SHADES.map((hex, i) => (
+          <span key={i} className="flex items-center gap-1">
+            <span
+              className="inline-block h-2.5 w-4 rounded"
+              style={{ backgroundColor: hex }}
+            />
+            <span>#{i + 1}</span>
+            <span className="text-[var(--color-text-light)]">
+              ({BORDA_WEIGHTS[i]}pt)
+            </span>
+          </span>
+        ))}
+      </div>
+
+      {/* Matrix — horizontal scroll for narrow viewports */}
       <div className="overflow-x-auto">
         <div className="inline-block">
-          {/* Column header row: #1 … #N */}
+          {/* Column headers: #1 … #N */}
           <div className="flex" style={{ paddingLeft: NAME_W }}>
             {scriptIds.map((sid, i) => (
               <div
@@ -160,80 +217,115 @@ export default function S4VoteMatrix({ events, totalPersonas }: S4VoteMatrixProp
           </div>
 
           {/* Voter rows */}
-          {rows.map((row) => (
-            <div key={row.personaId} className="flex">
-              <div
-                className="flex items-center justify-end pr-2 font-mono text-[10px] truncate"
-                style={{
-                  width: NAME_W,
-                  height: CELL,
-                  color:
-                    row.state === "voting"
-                      ? "var(--eval-a)"
-                      : row.state === "voted"
-                        ? "var(--color-text)"
-                        : "var(--color-text-muted)",
-                  opacity: row.state === "pending" ? 0.35 : 1,
-                }}
-                title={row.location ? `${row.displayName} — ${row.location}` : row.displayName}
-              >
-                {row.displayName}
-              </div>
-              {scriptIds.map((sid) => {
-                const picked = row.picks.has(sid);
-                let bg = "transparent";
-                let border = "1px solid var(--color-border)";
-                if (row.state === "voted") {
-                  bg = picked ? "var(--color-success)" : "var(--color-text-muted)";
-                  border = "1px solid " + (picked ? "var(--color-success)" : "var(--color-border)");
-                } else if (row.state === "voting") {
-                  bg = "var(--eval-a)";
-                  border = "1px solid var(--eval-a)";
-                }
-                return (
-                  <div
-                    key={sid}
+          {rows.map((row) => {
+            const subtitleParts = [
+              row.age != null ? `${row.age}y` : null,
+              row.occupation || null,
+              country(row.location) || null,
+            ].filter(Boolean);
+            return (
+              <div key={row.personaId} className="flex">
+                {/* Name sidebar — two lines */}
+                <div
+                  className="flex flex-col justify-center pr-2 truncate"
+                  style={{
+                    width: NAME_W,
+                    height: CELL,
+                    opacity: row.state === "pending" ? 0.35 : 1,
+                  }}
+                  title={row.location ? `${row.displayName} — ${row.location}` : row.displayName}
+                >
+                  <span
+                    className="font-mono text-[11px] leading-none truncate"
                     style={{
-                      width: CELL,
-                      height: CELL,
-                      backgroundColor: bg,
-                      opacity: row.state === "voted" && !picked ? 0.18 : row.state === "voting" ? 0.15 : 1,
-                      borderLeft: border,
-                      borderTop: border,
+                      color:
+                        row.state === "voting"
+                          ? "var(--eval-a)"
+                          : "var(--color-text)",
                     }}
-                    title={`${row.displayName} → ${sid}${picked ? " (picked)" : ""}`}
-                  />
-                );
-              })}
-            </div>
-          ))}
+                  >
+                    {row.displayName}
+                  </span>
+                  {subtitleParts.length > 0 && (
+                    <span className="font-ui text-[9px] leading-none text-[var(--color-text-muted)] truncate mt-0.5">
+                      {subtitleParts.join(" · ")}
+                    </span>
+                  )}
+                </div>
+                {/* Cells */}
+                {scriptIds.map((sid) => {
+                  const rank = row.ranks[sid];
+                  const picked = rank !== undefined;
+                  let bg = "transparent";
+                  if (row.state === "voted") {
+                    bg = picked ? RANK_SHADES[rank] : "var(--color-text-muted)";
+                  } else if (row.state === "voting") {
+                    bg = "var(--eval-a)";
+                  }
+                  const opacity =
+                    row.state === "voted" && !picked
+                      ? 0.18
+                      : row.state === "voting"
+                        ? 0.15
+                        : 1;
+                  return (
+                    <div
+                      key={sid}
+                      style={{
+                        width: CELL,
+                        height: CELL,
+                        backgroundColor: bg,
+                        opacity,
+                        borderLeft: "1px solid var(--color-border)",
+                        borderTop: "1px solid var(--color-border)",
+                      }}
+                      title={
+                        picked
+                          ? `${row.displayName} picked ${sid} at rank #${rank + 1} (+${BORDA_WEIGHTS[rank]}pt)`
+                          : `${row.displayName} → ${sid}`
+                      }
+                    />
+                  );
+                })}
+              </div>
+            );
+          })}
 
-          {/* Tally row — vote count per script */}
+          {/* Borda tally row */}
           <div className="flex mt-1" style={{ paddingLeft: NAME_W }}>
             {scriptIds.map((sid, i) => {
-              const n = columnVoteCounts[i];
-              const heightPct = (n / maxVotes) * 100;
+              const borda = columnBorda[i];
+              const votes = columnVoteCounts[i];
+              const heightPct = (borda / maxBorda) * 100;
               return (
                 <div
                   key={sid}
                   className="flex flex-col items-center justify-end"
-                  style={{ width: CELL, height: CELL * 1.5 }}
-                  title={`${sid}: ${n} votes`}
+                  style={{ width: CELL, height: CELL * 2 }}
+                  title={`${sid}: ${borda} Borda pts (${votes} picks)`}
                 >
                   <div
                     className="w-full"
                     style={{
                       height: `${heightPct}%`,
                       backgroundColor: "var(--eval-a)",
-                      opacity: 0.7,
+                      opacity: 0.75,
                     }}
                   />
-                  <span className="font-mono text-[9px] text-[var(--color-text-muted)] mt-0.5">
-                    {n}
+                  <span className="font-mono text-[9px] text-[var(--color-text)] mt-0.5 font-medium">
+                    {borda}
                   </span>
                 </div>
               );
             })}
+          </div>
+          <div className="flex" style={{ paddingLeft: NAME_W }}>
+            <span
+              className="font-ui text-[9px] uppercase tracking-[0.1em] text-[var(--color-text-muted)]"
+              style={{ width: CELL * scriptIds.length }}
+            >
+              Borda score (rank-weighted) · S5 uses these to pick top 10
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Three upgrades to the vote matrix based on the check-in.

## 1. Rank gradient (5 shades of green)

You were right that flat green loses signal. The \`vote_cast\` event already carries the ordered \`top_5\` — we just needed to use the index.

| Rank in voter's top-5 | Color | Borda weight |
|---|---|---|
| #1 | teal-700 (darkest) | 5pt |
| #2 | teal-500 | 4pt |
| #3 | teal-300 | 3pt |
| #4 | teal-200 | 2pt |
| #5 | teal-100 (lightest) | 1pt |

A small legend renders above the matrix so the encoding is obvious.

## 2. Borda-weighted bottom tally

The tally bar under each column now shows **Borda score** (5 × rank-1 picks + 4 × rank-2 + …), not raw vote count. This exactly mirrors \`S5.rank\` (\`backend/app/pipeline/stages/s5_rank.py:15\`), so the tall columns in the tally row ARE the scripts that will win S5. Raw vote count still appears on hover.

Added a label under the bars: *"Borda score (rank-weighted) · S5 uses these to pick top 10"* — makes the relationship explicit.

## 3. Persona bio sidebar (widened)

Sidebar column widened 96px → 180px. Two-line rows:
- Line 1: first name (e.g. \`Carmen\`, \`Grace\`, \`Kenji\`) in mono
- Line 2: \`25y · college student · Canada\` in sans, muted

Backend change: \`s4_task_started\` now emits \`age\` + \`occupation\` in addition to \`name\` + \`location\`. The country is extracted from the last comma-segment of \`location\` (matches how \`personas.json\` is structured: "São Paulo, Brazil" → "Brazil").

Pending rows fade to 35% opacity, voting rows show first-name in teal (eval-a), voted rows show first-name in default text color.

## Test plan
- [x] \`ruff check .\` clean
- [x] 112 backend tests pass
- [x] \`astro check\` clean
- [ ] After deploy: run a pipeline, confirm
    - [ ] rows show \`Carmen · 25y · college student · Canada\` style bios
    - [ ] first-pick cells are visibly darker than fifth-pick cells
    - [ ] a tall bar in the tally row corresponds to the #1 entry on the \`/results\` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)