### PR TITLE
fix: /results/{id} link + Celery concurrency ceiling (8 → 20)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -53,5 +53,5 @@ EXPOSE 8000
 
 # API service default CMD
 # Celery worker overrides this in ECS task definition:
-#   celery -A app.worker worker --loglevel=info --concurrency=4
+#   celery -A app.worker worker --loglevel=info --pool=threads --concurrency=20
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   worker:
     build:
       context: ./backend
-    command: celery -A app.workers.celery_app worker --loglevel=info --concurrency=4
+    command: celery -A app.workers.celery_app worker --loglevel=info --pool=threads --concurrency=20
     environment:
       FLAIR2_REDIS_URL: redis://redis:6379/0
       FLAIR2_CELERY_BROKER_URL: redis://redis:6379/1

--- a/frontend/src/components/RunsList.tsx
+++ b/frontend/src/components/RunsList.tsx
@@ -22,7 +22,10 @@ function statusColor(status: string): string {
 }
 
 function linkFor(run: RunStatus): string {
-  if (run.status === "completed") return `/results/${run.run_id}`;
+  // Query-string form, not path — S3 static hosting only pre-generates
+  // the bare /results/ and /pipeline/ routes; any path-style ID 404s
+  // and falls through to the index.html error document.
+  if (run.status === "completed") return `/results/?id=${run.run_id}`;
   return `/pipeline/?id=${run.run_id}`;
 }
 

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -144,10 +144,14 @@ resource "aws_ecs_task_definition" "worker" {
     image     = var.ecr_worker_image_url
     essential = true
 
-    # Override CMD to start Celery instead of FastAPI
+    # Override CMD to start Celery instead of FastAPI.
+    # Threads pool + high concurrency: our tasks are I/O-bound (awaiting
+    # Kimi responses), so threads are the right primitive. Each thread
+    # adds ~8 MB of stack vs ~250 MB per prefork process, and the
+    # RedisSemaphore throttles the total at 29 anyway.
     command = [
       "celery", "-A", "app.workers.celery_app", "worker",
-      "--loglevel=info", "--concurrency=4"
+      "--loglevel=info", "--pool=threads", "--concurrency=20"
     ]
 
     environment = [


### PR DESCRIPTION
Two related bugs from the post-deploy check-in.

## 1. RUNS → completed run → home page instead of results

My \`linkFor()\` in #149 used \`/results/{id}\` path form. But S3 static hosting only pre-generates \`/results/\` (from the \`[...id].astro\` static-paths wildcard) — any path-based ID 404s and falls through to S3's error document, which is configured as \`index.html\`. That's why the home page rendered.

The app's established convention is **\`?id=X\` query-string routing** (already used by \`VotingAnimation.tsx\` and \`useRouteId()\`). Switched \`linkFor()\` to match.

## 2. "Only 8 concurrent" during S1

The 29-slot Redis semaphore I added in #143 is the *Kimi* ceiling. **Celery itself** was limiting us to 8 — 2 worker tasks × \`--concurrency=4\` prefork.

Prefork is the wrong pool for this workload:
- Every task is I/O-bound (just awaiting Kimi HTTP responses)
- Prefork costs ~250 MB per slot (full Python process)
- We could only run 8 because more processes wouldn't fit in memory

Switch ECS command to **\`--pool=threads --concurrency=20\`**:
- 2 workers × 20 threads = 40 potential in-flight calls
- RedisSemaphore throttles to 29 (Kimi's documented cap)
- Thread stacks ~8 MB each — plenty of headroom in the 2 GB budget
- \`asyncio.run()\` inside threads creates a fresh event loop per thread, which is the supported pattern

Also updated \`docker-compose.yml\` and the Dockerfile CMD comment to match, so local dev and prod agree.

Confirmed no Celery signals in the codebase (grepped \`worker_process_init\` etc.), so the prefork → threads switch won't break lifecycle hooks we rely on.

## Expected effect post-deploy
- S1 concurrency reading goes from **"8 concurrent"** to **"~20 concurrent"** during peak
- S1 wall-clock for 100 videos drops roughly proportionally (was ~2 min, should drop to ~1 min)

## Test plan
- [x] \`astro check\` — 0 errors, 0 warnings, 0 hints
- [x] 112 backend tests pass (no Celery-pool code-path changes in tests)
- [ ] Post-deploy: click a completed run in RUNS → lands on results, not home
- [ ] Post-deploy: fresh S1 stage shows concurrent counter climbing above 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)