### PR TITLE
feat: sample Creator Profiles with one-click form populate

### DIFF
--- a/backend/app/api/routes/creator_profiles.py
+++ b/backend/app/api/routes/creator_profiles.py
@@ -1,0 +1,39 @@
+"""Sample creator profiles for the Create form's "Load example" dropdown.
+
+Reads from backend/data/sample_creator_profiles.json at startup so new
+profiles can be added without a code change.
+"""
+
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.models.pipeline import CreatorProfile
+
+router = APIRouter(tags=["creator-profiles"])
+
+_SAMPLES_PATH = Path("data/sample_creator_profiles.json")
+
+
+class SampleCreatorProfile(BaseModel):
+    id: str
+    label: str
+    description: str
+    profile: CreatorProfile
+
+
+@router.get(
+    "/api/creator-profiles/samples",
+    response_model=list[SampleCreatorProfile],
+)
+async def list_sample_profiles() -> list[SampleCreatorProfile]:
+    """Return the pre-authored creator profiles used to seed the form."""
+    if not _SAMPLES_PATH.exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"Sample profiles file not found at {_SAMPLES_PATH}",
+        )
+    data = json.loads(_SAMPLES_PATH.read_text())
+    return [SampleCreatorProfile(**entry) for entry in data]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.deps import close_redis
-from app.api.routes import health, performance, pipeline, providers, video
+from app.api.routes import (
+    creator_profiles,
+    health,
+    performance,
+    pipeline,
+    providers,
+    video,
+)
 from app.config import settings
 
 logger = structlog.get_logger()
@@ -56,3 +63,4 @@ app.include_router(pipeline.router)
 app.include_router(video.router)
 app.include_router(performance.router)
 app.include_router(providers.router)
+app.include_router(creator_profiles.router)

--- a/backend/data/sample_creator_profiles.json
+++ b/backend/data/sample_creator_profiles.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "movedaily",
+    "label": "MoveDaily",
+    "description": "Dorm-friendly fitness for college students",
+    "profile": {
+      "tone": "energetic, no-nonsense, practical",
+      "vocabulary": ["rep", "set", "PR", "form over ego", "gains", "compound", "bodyweight", "progressive overload"],
+      "catchphrases": ["let's get it", "form over ego", "bodyweight beats no weights"],
+      "topics_to_avoid": ["supplements", "diet shaming", "expensive gyms"],
+      "niche": "college-dorm fitness",
+      "audience_description": "College students 18-24 living in dorms who want to get fit without a gym membership",
+      "content_themes": ["dorm workouts", "10-minute routines", "progression tracking", "form breakdowns", "bodyweight basics"],
+      "example_hooks": ["I did 100 push-ups a day for 30 days and here's what actually changed", "Your dorm room has everything you need for a back workout", "The pull-up progression that actually works for beginners"],
+      "recent_topics": ["push-up variations", "morning routines", "bodyweight back workouts", "progressive overload for beginners"]
+    }
+  },
+  {
+    "id": "budgetbuilt",
+    "label": "Budget Built",
+    "description": "Personal finance for early-career Gen Z",
+    "profile": {
+      "tone": "calm, analytical, skeptical of hype",
+      "vocabulary": ["APR", "401(k)", "index fund", "compound", "emergency fund", "Roth", "HYSA", "diversify", "expense ratio"],
+      "catchphrases": ["the math works out", "future you will thank you", "don't chase yields"],
+      "topics_to_avoid": ["meme stocks", "crypto gambling", "get-rich-quick", "day trading"],
+      "niche": "early-career personal finance",
+      "audience_description": "22-28 year olds starting their first real job, worried about student debt and housing costs",
+      "content_themes": ["first paycheck breakdowns", "retirement basics", "student loan strategies", "rent vs buy math", "tax withholding"],
+      "example_hooks": ["I've never made more than $60k and I'll still retire at 50", "Everyone's first 401(k) mistake costs them $200k", "The real cost of your $5 daily coffee isn't what you think"],
+      "recent_topics": ["Roth conversions", "HYSA yield comparisons", "employer match basics", "health-savings accounts"]
+    }
+  },
+  {
+    "id": "kitchenconfident",
+    "label": "Kitchen Confident",
+    "description": "Weeknight cooking for busy adults",
+    "profile": {
+      "tone": "warm, encouraging, low-stakes, pragmatic",
+      "vocabulary": ["sheet pan", "one-pot", "meal prep", "batch cook", "deglaze", "season to taste", "pantry staple", "swap"],
+      "catchphrases": ["it doesn't have to be perfect", "close enough is good", "taste as you go"],
+      "topics_to_avoid": ["expensive gadgets", "celebrity chef drama", "diet culture", "food shaming"],
+      "niche": "weeknight home cooking",
+      "audience_description": "Working adults 25-40 who want to cook more but feel short on time and budget",
+      "content_themes": ["30-minute dinners", "pantry cooking", "one-pot meals", "ingredient substitutions", "budget tips"],
+      "example_hooks": ["This pasta saved my whole week and cost me $6", "I stopped meal prepping and I cook better than ever", "The one-pot chicken thigh recipe I make every single week"],
+      "recent_topics": ["one-pan chicken thighs", "15-minute weeknight soups", "freezer burrito batch cook", "pantry pasta variations"]
+    }
+  },
+  {
+    "id": "stackoverhead",
+    "label": "StackOverhead",
+    "description": "Dev tools & tech reviews for engineers",
+    "profile": {
+      "tone": "analytical, dry-humored, opinionated but evidence-based",
+      "vocabulary": ["benchmark", "throughput", "DX", "idiomatic", "refactor", "yak-shaving", "footgun", "JSON-schlep"],
+      "catchphrases": ["it depends", "but actually", "measure before you optimize"],
+      "topics_to_avoid": ["language wars", "crypto", "AI hype", "ten-year-old best-practice rehashes"],
+      "niche": "developer tools and productivity",
+      "audience_description": "Software engineers 24-40 — mid-career opinion-formers who evaluate tooling carefully",
+      "content_themes": ["editor setups", "CLI tools", "language runtimes", "build systems", "terminal productivity"],
+      "example_hooks": ["I switched from VS Code for a week and here's what surprised me", "This build tool is 40% faster than webpack and nobody uses it", "Your CI is slow for one very fixable reason"],
+      "recent_topics": ["uv vs pip performance", "tmux configs", "fish vs zsh daily-driver review", "neovim transition notes"]
+    }
+  },
+  {
+    "id": "skinfacts",
+    "label": "SkinFacts",
+    "description": "Evidence-based skincare, no-BS",
+    "profile": {
+      "tone": "confident, science-forward, slightly irreverent",
+      "vocabulary": ["retinol", "niacinamide", "actives", "barrier function", "fragrance-free", "ingredient list", "patch test", "sunscreen"],
+      "catchphrases": ["read the label", "the skincare industry lied to you", "sunscreen or it didn't happen"],
+      "topics_to_avoid": ["body shaming", "MLM brands", "fast-beauty trends", "injectable promotion"],
+      "niche": "evidence-based skincare",
+      "audience_description": "20-35 year old women tired of skincare marketing, looking for products that actually work",
+      "content_themes": ["routine simplification", "ingredient deep-dives", "product swaps at every price point", "sunscreen education", "barrier repair"],
+      "example_hooks": ["The $8 serum that out-performs $80 ones in every category", "I threw out half my skincare and my skin cleared up in a week", "Everything you've been told about retinol is wrong"],
+      "recent_topics": ["retinol intro routines", "SPF 50 comparisons", "fragrance-free moisturizer picks", "barrier-repair cleansers"]
+    }
+  },
+  {
+    "id": "aloneonward",
+    "label": "Alone Onward",
+    "description": "Solo budget-travel for first-timers",
+    "profile": {
+      "tone": "reassuring, curious, grounded, hopeful",
+      "vocabulary": ["hostel", "layover", "carry-on", "shoulder season", "slow travel", "local bus", "eSIM", "cash-only"],
+      "catchphrases": ["the hardest part is booking", "you'll figure it out on the ground", "nobody's watching you"],
+      "topics_to_avoid": ["luxury travel", "digital nomad hype", "visa politics", "destination shaming"],
+      "niche": "solo budget international travel",
+      "audience_description": "23-35 year olds who want to travel alone but feel intimidated by the logistics",
+      "content_themes": ["first-trip checklists", "language basics", "minimalist packing", "solo-safety practicalities", "local transit"],
+      "example_hooks": ["I traveled for a month on $500 and slept in a real bed every night", "What nobody tells you about your first solo trip", "The one app that replaced my entire travel wallet"],
+      "recent_topics": ["Lisbon on foot", "night-bus overnights in Vietnam", "hostel dorm etiquette", "eSIM setup for Europe"]
+    }
+  }
+]

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -224,6 +224,19 @@ export function getProviders(): Promise<Providers> {
   return request("/api/providers");
 }
 
+// ── Sample Creator Profiles ────────────────────────────────
+
+export interface SampleCreatorProfile {
+  id: string;
+  label: string;
+  description: string;
+  profile: CreatorProfile;
+}
+
+export function getSampleCreatorProfiles(): Promise<SampleCreatorProfile[]> {
+  return request("/api/creator-profiles/samples");
+}
+
 // ── Video ──────────────────────────────────────────────────
 
 export function generateVideo(

--- a/frontend/src/pages/create.astro
+++ b/frontend/src/pages/create.astro
@@ -17,6 +17,19 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     </div>
 
     <form id="create-form" class="flex flex-col gap-8">
+      <!-- Quick Start — load an example profile -->
+      <section class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+        <label class="mb-1.5 block text-sm font-medium" for="example_profile">
+          Quick Start — Load an Example Profile
+        </label>
+        <select id="example_profile" class="input-field">
+          <option value="">Loading examples…</option>
+        </select>
+        <p class="mt-1 text-xs text-[var(--color-text-muted)]">
+          Populates the form with a sample creator profile. Customize freely after loading, or pick "Start from scratch" to clear.
+        </p>
+      </section>
+
       <!-- Creator Profile -->
       <section class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
         <h2 class="mb-5 text-lg font-semibold">Creator Profile</h2>
@@ -237,7 +250,12 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 </style>
 
 <script>
-  import { getProviders, startPipeline } from "../lib/api-client";
+  import {
+    getProviders,
+    getSampleCreatorProfiles,
+    startPipeline,
+    type SampleCreatorProfile,
+  } from "../lib/api-client";
 
   // ── Model dropdowns ─────────────────────────────────────
 
@@ -259,6 +277,61 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     .catch(() => {
       reasoningEl.innerHTML = `<option value="">Failed to load — check API</option>`;
       videoEl.innerHTML = `<option value="">Skip video</option>`;
+    });
+
+  // ── Sample profile dropdown ─────────────────────────────
+
+  const exampleEl = document.getElementById("example_profile") as HTMLSelectElement;
+
+  function setField(id: string, value: string) {
+    const el = document.getElementById(id) as HTMLInputElement | null;
+    if (!el) return;
+    el.value = value;
+    // Fire input event so PromptPreview + any other observers react.
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  const PROFILE_FIELDS: Array<[string, (p: SampleCreatorProfile["profile"]) => string]> = [
+    ["tone", (p) => p.tone],
+    ["catchphrases", (p) => (p.catchphrases || []).join(", ")],
+    ["vocabulary", (p) => (p.vocabulary || []).join(", ")],
+    ["topics_to_avoid", (p) => (p.topics_to_avoid || []).join(", ")],
+    ["niche", (p) => p.niche || ""],
+    ["audience_description", (p) => p.audience_description || ""],
+    ["content_themes", (p) => (p.content_themes || []).join(", ")],
+    ["example_hooks", (p) => (p.example_hooks || []).join(", ")],
+    ["recent_topics", (p) => (p.recent_topics || []).join(", ")],
+  ];
+
+  function clearProfileFields() {
+    for (const [id] of PROFILE_FIELDS) setField(id, "");
+  }
+
+  function applyProfile(p: SampleCreatorProfile["profile"]) {
+    for (const [id, getter] of PROFILE_FIELDS) setField(id, getter(p));
+  }
+
+  getSampleCreatorProfiles()
+    .then((samples) => {
+      exampleEl.innerHTML =
+        `<option value="">— Start from scratch —</option>` +
+        samples
+          .map((s) => `<option value="${s.id}">${s.label} — ${s.description}</option>`)
+          .join("");
+
+      exampleEl.addEventListener("change", () => {
+        const id = exampleEl.value;
+        if (!id) {
+          clearProfileFields();
+          return;
+        }
+        const selected = samples.find((s) => s.id === id);
+        if (selected) applyProfile(selected.profile);
+      });
+    })
+    .catch(() => {
+      exampleEl.innerHTML = `<option value="">Failed to load examples</option>`;
+      exampleEl.disabled = true;
     });
 
   // ── Advanced toggle ─────────────────────────────────────


### PR DESCRIPTION
## 6 hand-authored profiles
Each genuinely distinct — different vocabulary, catchphrases, audience, content themes. They're meant to produce noticeably different S6 output when you swap between them for testing.

| ID | Label | Niche |
|---|---|---|
| \`movedaily\` | **MoveDaily** | Dorm-friendly fitness for college students |
| \`budgetbuilt\` | **Budget Built** | Personal finance for early-career Gen Z |
| \`kitchenconfident\` | **Kitchen Confident** | Weeknight cooking for busy adults |
| \`stackoverhead\` | **StackOverhead** | Dev tools & tech reviews for engineers |
| \`skinfacts\` | **SkinFacts** | Evidence-based skincare, no-BS |
| \`aloneonward\` | **Alone Onward** | Solo budget-travel for first-timers |

Each one includes filled-in values for all 9 fields — tone, vocabulary, catchphrases, topics_to_avoid, niche, audience_description, content_themes, example_hooks, recent_topics.

## Backend
- \`backend/data/sample_creator_profiles.json\` — source of truth, hand-editable
- \`GET /api/creator-profiles/samples\` — returns the list (validated against the existing \`CreatorProfile\` model so the shape stays honest)

Adding or tweaking profiles later = edit the JSON, commit, deploy. No code changes required.

## Frontend
New **Quick Start** section at the top of the Create form with a dropdown:
\`\`\`
Quick Start — Load an Example Profile
  — Start from scratch —
  MoveDaily — Dorm-friendly fitness for college students
  Budget Built — Personal finance for early-career Gen Z
  Kitchen Confident — Weeknight cooking for busy adults
  …
\`\`\`

Picking a sample fires \`input\` events on every populated field, so the \`PromptPreview\` (from #153) updates instantly — you get a live before/after of how each sample shapes the S6 prompt. Picking "— Start from scratch —" clears the profile fields.

## Scope
- \`data/\` file lives inside \`backend/\`, so the existing Dockerfile \`COPY data/ ./data/\` picks it up — no deploy-path change needed (same fix as #144 set up).
- The Quick Start section is **above** the Creator Profile section but still inside the form so layout order matches the user's mental flow (pick example → adjust → submit).

## Test plan
- [x] \`ruff check .\` clean
- [x] 112 backend tests pass
- [x] \`astro check\` clean (0/0/0)
- [ ] After deploy: load \`/create\` → dropdown is populated with 6 labels
- [ ] Pick "Kitchen Confident" → form fills in; PromptPreview S6 tab shows those values in colored chips
- [ ] Pick "— Start from scratch —" → fields clear
- [ ] Start a pipeline with the sample unchanged → S6 output clearly reflects the creator's voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)