### PR TITLE
fix: retry on schema mismatch, not just JSON-decode errors

### DIFF
--- a/backend/app/providers/gemini.py
+++ b/backend/app/providers/gemini.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 
 import structlog
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from app.config import settings
 from app.models.errors import InvalidResponseError, ProviderError, RateLimitError
@@ -66,17 +66,20 @@ class GeminiProvider:
                 if schema:
                     json_str = extract_json(text)
                     try:
-                        json.loads(json_str)
-                    except json.JSONDecodeError as e:
+                        parsed = json.loads(json_str)
+                        schema.model_validate(parsed)
+                    except (json.JSONDecodeError, ValidationError) as e:
                         if attempt < MAX_RETRIES - 1:
                             logger.warning(
-                                "invalid_json_response",
+                                "gemini_invalid_schema",
                                 attempt=attempt,
-                                error=str(e),
+                                schema=schema.__name__,
+                                error=str(e)[:300],
                             )
                             continue
                         raise InvalidResponseError(
-                            f"Failed to parse JSON after {MAX_RETRIES} attempts",
+                            f"Failed to produce valid {schema.__name__} "
+                            f"after {MAX_RETRIES} attempts: {str(e)[:200]}",
                             provider=self.name,
                             raw_response=text,
                         ) from e

--- a/backend/app/providers/kimi.py
+++ b/backend/app/providers/kimi.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 
 import structlog
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from app.config import settings
 from app.models.errors import InvalidResponseError, ProviderError, RateLimitError
@@ -79,16 +79,26 @@ class KimiProvider:
 
                 if schema:
                     json_str = extract_json(text)
+                    # Validate BOTH parse and schema-match: the LLM sometimes
+                    # returns parseable JSON with the wrong shape (e.g. S3's
+                    # hook/body/payoff when asked for S1's hook_type/pacing).
+                    # Retrying in-provider is cheaper than letting the stage
+                    # raise StageError, which bypasses Celery's retry path.
                     try:
-                        json.loads(json_str)
-                    except json.JSONDecodeError as e:
+                        parsed = json.loads(json_str)
+                        schema.model_validate(parsed)
+                    except (json.JSONDecodeError, ValidationError) as e:
                         if attempt < MAX_RETRIES - 1:
                             logger.warning(
-                                "kimi_invalid_json", attempt=attempt, error=str(e)
+                                "kimi_invalid_schema",
+                                attempt=attempt,
+                                schema=schema.__name__,
+                                error=str(e)[:300],
                             )
                             continue
                         raise InvalidResponseError(
-                            f"Failed to parse JSON after {MAX_RETRIES} attempts",
+                            f"Failed to produce valid {schema.__name__} "
+                            f"after {MAX_RETRIES} attempts: {str(e)[:200]}",
                             provider=self.name,
                             raw_response=text,
                         ) from e

--- a/backend/tests/unit/test_kimi_provider.py
+++ b/backend/tests/unit/test_kimi_provider.py
@@ -2,8 +2,14 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
 
+from app.models.errors import InvalidResponseError
 from app.providers.kimi import KimiProvider
+
+
+class _TinySchema(BaseModel):
+    key: str
 
 
 @pytest.fixture
@@ -55,7 +61,7 @@ class TestGenerateText:
             mock_client = MagicMock()
             mock_client.messages.create = AsyncMock(return_value=mock_resp)
             mock_client_fn.return_value = mock_client
-            result = await kimi_provider.generate_text("Give JSON", schema=dict)
+            result = await kimi_provider.generate_text("Give JSON", schema=_TinySchema)
             parsed = json.loads(result)
             assert parsed == {"key": "value"}
 
@@ -96,14 +102,43 @@ class TestRetryBehavior:
     @pytest.mark.asyncio
     async def test_retries_on_invalid_json(self, kimi_provider):
         bad_resp = _mock_message("not json")
-        good_resp = _mock_message('{"valid": true}')
+        good_resp = _mock_message('{"key": "ok"}')
         with patch.object(kimi_provider, "_get_client") as mock_client_fn:
             mock_client = MagicMock()
             mock_client.messages.create = AsyncMock(side_effect=[bad_resp, good_resp])
             mock_client_fn.return_value = mock_client
-            result = await kimi_provider.generate_text("Give JSON", schema=dict)
-            assert json.loads(result) == {"valid": True}
+            result = await kimi_provider.generate_text("Give JSON", schema=_TinySchema)
+            assert json.loads(result) == {"key": "ok"}
             assert mock_client.messages.create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_schema_mismatch(self, kimi_provider):
+        """Valid JSON but wrong shape — retry, don't fail immediately."""
+        wrong_shape = _mock_message('{"not_the_right_field": "oops"}')
+        right_shape = _mock_message('{"key": "recovered"}')
+        with patch.object(kimi_provider, "_get_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(
+                side_effect=[wrong_shape, right_shape]
+            )
+            mock_client_fn.return_value = mock_client
+            result = await kimi_provider.generate_text(
+                "Give JSON", schema=_TinySchema
+            )
+            assert json.loads(result) == {"key": "recovered"}
+            assert mock_client.messages.create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_invalid_response_after_max_schema_retries(self, kimi_provider):
+        wrong = _mock_message('{"not_the_right_field": "oops"}')
+        with patch.object(kimi_provider, "_get_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=wrong)
+            mock_client_fn.return_value = mock_client
+            with pytest.raises(InvalidResponseError) as exc_info:
+                await kimi_provider.generate_text("Give JSON", schema=_TinySchema)
+            assert "_TinySchema" in str(exc_info.value)
+            assert mock_client.messages.create.call_count == 3
 
 
 class TestAnalyzeContent:


### PR DESCRIPTION
## The bug you just hit

S1 failed for one video with a 4-field pydantic validation error. The LLM returned:
\`\`\`json
{"hook": "关系冲突开…", "video_id": "7520005543470189837"}
\`\`\`
— which is **S3's shape** (hook/body/payoff), not S1's (hook_type/pacing/pattern_interrupts/…). The model drifted off-prompt, but the response was still parseable JSON.

The provider's retry loop only catches \`json.JSONDecodeError\`, so the bad response passed through. The stage then tried \`S1Pattern(**data)\` which raised \`pydantic.ValidationError\`. That got caught as \`StageError\`. And \`StageError\` **doesn't trigger Celery's retry path** — one bad LLM response killed the whole pipeline at 45/100.

## The fix

The provider already receives the pydantic schema as a parameter — it just wasn't using it for validation. Now it does:

\`\`\`python
if schema:
    json_str = extract_json(text)
    try:
        parsed = json.loads(json_str)
        schema.model_validate(parsed)  # NEW — catches schema drift
    except (json.JSONDecodeError, ValidationError) as e:
        if attempt < MAX_RETRIES - 1:
            logger.warning(
                "kimi_invalid_schema",
                attempt=attempt,
                schema=schema.__name__,
                error=str(e)[:300],
            )
            continue
        raise InvalidResponseError(
            f"Failed to produce valid {schema.__name__} "
            f"after {MAX_RETRIES} attempts: {str(e)[:200]}",
            provider=self.name,
            raw_response=text,
        ) from e
\`\`\`

3 attempts gives the LLM room to self-correct. By the time we raise \`InvalidResponseError\`, we've shown the user a meaningful error message with the schema name.

Applied symmetrically to \`gemini.py\` for consistency.

## Tests

Kimi tests updated to use a real pydantic model (\`_TinySchema\`) instead of bare \`dict\` — \`dict\` doesn't have \`.model_validate\`. Two new tests for the new branch:

- \`test_retries_on_schema_mismatch\` — wrong shape then right shape → one retry, returns good result
- \`test_raises_invalid_response_after_max_schema_retries\` — wrong shape three times → \`InvalidResponseError\` with schema name in message

114 backend tests pass (was 112, +2 new). ruff clean.

## What this does **not** fix — "still 8 concurrent"

Separate issue I under-communicated in #152: the terraform code change (\`--pool=threads --concurrency=20\`) doesn't take effect until you run \`terraform apply\`. The deploy workflow only runs \`aws ecs update-service --force-new-deployment\`, which pulls the new image but uses the existing task definition. ECS is still starting workers with \`--concurrency=4\` from the old task def.

To pick up #152's command change:
\`\`\`bash
cd terraform
terraform apply -var-file=environments/dev.tfvars
\`\`\`

(Shows a diff on \`aws_ecs_task_definition.worker\`, rolls new tasks. ~3 min.) After that, S1 should actually show "20 concurrent" during peak.

## Test plan
- [x] \`ruff check .\` clean
- [x] 114 tests pass
- [ ] Post-deploy: trigger a run where an LLM call returns a drifted shape → log should show \`kimi_invalid_schema\` warning, retry, and succeed instead of killing the pipeline
- [ ] Separate: after \`terraform apply\`, S1 shows >8 concurrent

🤖 Generated with [Claude Code](https://claude.com/claude-code)