### PR TITLE
fix: one bad S1 video no longer kills the whole run (skip-and-continue)

### DIFF
--- a/backend/app/pipeline/orchestrator.py
+++ b/backend/app/pipeline/orchestrator.py
@@ -88,6 +88,34 @@ class Orchestrator:
         if done >= config.num_videos:
             await self._transition_s2(run_id)
 
+    async def on_s1_skipped(
+        self, run_id: str, video_id: str, reason: str,
+    ) -> None:
+        """Mark one video as un-analyzable after retries exhausted.
+
+        Bumps the same counter as a successful analysis so S2 can still
+        trigger when the last video is processed. One bad input should
+        never block the other 99.
+        """
+        done = await self._r.incr(f"run:{run_id}:s1:done")
+        config = await self._load_config(run_id)
+
+        await self._xadd_event(run_id, "s1_video_skipped", {
+            "video_id": video_id,
+            "reason": reason[:300],
+            "completed": done,
+            "total": config.num_videos,
+        })
+        logger.warning(
+            "orchestrator_s1_video_skipped",
+            run_id=run_id,
+            video_id=video_id,
+            reason=reason[:200],
+        )
+
+        if done >= config.num_videos:
+            await self._transition_s2(run_id)
+
     async def on_s2_complete(self, run_id: str, pattern_count: int = 0) -> None:
         await self._xadd_event(run_id, "s2_complete", {"pattern_count": pattern_count})
         await self._transition_s3(run_id)

--- a/backend/app/workers/tasks.py
+++ b/backend/app/workers/tasks.py
@@ -12,6 +12,7 @@ Tasks are sync; async work runs inside asyncio.run().
 """
 
 import asyncio
+import contextlib
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -68,6 +69,16 @@ async def _report_failure(run_id: str, stage: str, error: str) -> None:
         await redis.aclose()
 
 
+async def _skip_s1_video(run_id: str, video_id: str, reason: str) -> None:
+    """Mark one S1 video as un-analyzable without killing the whole run."""
+    redis = RedisClient(settings.redis_url)
+    try:
+        from app.pipeline.orchestrator import Orchestrator
+        await Orchestrator(redis).on_s1_skipped(run_id, video_id, reason)
+    finally:
+        await redis.aclose()
+
+
 async def _acquire_rate_limit_token(redis: RedisClient, provider_name: str) -> None:
     """Wait for a rate-limit token before making an LLM call.
 
@@ -112,6 +123,12 @@ async def _acquire_provider_slot(
 
 @celery_app.task(bind=True, max_retries=3, default_retry_delay=4)
 def s1_analyze_task(self, run_id: str, video_json: str):
+    # Parse video_id up-front so the exception handlers can reference it
+    # when skipping — video_json might still be malformed, fall through.
+    video_id: str | None = None
+    with contextlib.suppress(Exception):
+        video_id = json.loads(video_json).get("video_id")
+
     async def _run():
         redis = RedisClient(settings.redis_url)
         try:
@@ -145,13 +162,30 @@ def s1_analyze_task(self, run_id: str, video_json: str):
         try:
             raise self.retry(exc=exc) from exc
         except self.MaxRetriesExceededError:
-            logger.error("s1_retries_exhausted", run_id=run_id, error=str(exc))
-            asyncio.run(_report_failure(run_id, "S1", f"Provider error after retries: {exc}"))
+            # One un-analyzable video (sparse description, LLM schema drift,
+            # etc.) should not kill the other 99. Mark it skipped and let S2
+            # aggregate whatever patterns succeeded.
+            logger.error(
+                "s1_retries_exhausted",
+                run_id=run_id,
+                video_id=video_id,
+                error=str(exc),
+            )
+            msg = f"Provider error after retries: {exc}"
+            if video_id:
+                asyncio.run(_skip_s1_video(run_id, video_id, msg))
+            else:
+                asyncio.run(_report_failure(run_id, "S1", msg))
     except StageError as exc:
-        logger.error("s1_stage_error", run_id=run_id, error=str(exc))
-        asyncio.run(_report_failure(run_id, "S1", str(exc)))
+        logger.error("s1_stage_error", run_id=run_id, video_id=video_id, error=str(exc))
+        if video_id:
+            asyncio.run(_skip_s1_video(run_id, video_id, str(exc)))
+        else:
+            asyncio.run(_report_failure(run_id, "S1", str(exc)))
     except Exception as exc:
-        logger.error("s1_unexpected_error", run_id=run_id, error=str(exc))
+        # Unexpected failures — could be infra. Still halt, since we don't
+        # know if the rest of the pipeline can recover.
+        logger.error("s1_unexpected_error", run_id=run_id, video_id=video_id, error=str(exc))
         asyncio.run(_report_failure(run_id, "S1", f"Unexpected error: {exc}"))
 
 

--- a/backend/tests/unit/test_orchestrator.py
+++ b/backend/tests/unit/test_orchestrator.py
@@ -141,6 +141,49 @@ async def test_on_s1_complete_increments_counter(redis, config, videos):
         mock_s2.delay.assert_called_once_with("test-run")
 
 
+async def test_on_s1_skipped_still_transitions_to_s2(redis, config, videos):
+    """One bad video should not block S2 — skipped counts toward the threshold."""
+    with patch("app.workers.tasks.s1_analyze_task") as mock_task:
+        mock_task.delay = MagicMock()
+        await Orchestrator(redis).start("test-run", config, videos)
+
+    with patch("app.workers.tasks.s2_aggregate_task") as mock_s2:
+        mock_s2.delay = MagicMock()
+        orch = Orchestrator(redis)
+        await orch.on_s1_complete("test-run", "v0")
+        await orch.on_s1_complete("test-run", "v1")
+        # v2 can't be analyzed — skip it
+        await orch.on_s1_skipped("test-run", "v2", reason="sparse content")
+        # Counter reached num_videos=3 despite the skip → S2 runs
+        assert await redis.get("run:test-run:s1:done") == "3"
+        mock_s2.delay.assert_called_once_with("test-run")
+
+
+async def test_on_s1_skipped_emits_event(redis, config, videos):
+    with patch("app.workers.tasks.s1_analyze_task") as mock_task:
+        mock_task.delay = MagicMock()
+        await Orchestrator(redis).start("test-run", config, videos)
+
+    with patch("app.workers.tasks.s2_aggregate_task") as mock_s2:
+        mock_s2.delay = MagicMock()
+        await Orchestrator(redis).on_s1_skipped(
+            "test-run", "v_bad", reason="Provider error after retries"
+        )
+
+    entries = await redis.xread({"sse:test-run": "0-0"}, block=100, count=50)
+    payloads = [
+        json.loads(fields["payload"])
+        for _stream, msgs in entries
+        for _id, fields in msgs
+    ]
+    skipped = [p for p in payloads if p["event"] == "s1_video_skipped"]
+    assert len(skipped) == 1
+    assert skipped[0]["data"]["video_id"] == "v_bad"
+    assert "Provider error" in skipped[0]["data"]["reason"]
+    assert skipped[0]["data"]["completed"] == 1
+    assert skipped[0]["data"]["total"] == 3
+
+
 async def test_s1_complete_transitions_stage(redis, config, videos):
     with patch("app.workers.tasks.s1_analyze_task") as mock_task:
         mock_task.delay = MagicMock()

--- a/frontend/src/components/PipelineVisualizer.tsx
+++ b/frontend/src/components/PipelineVisualizer.tsx
@@ -99,7 +99,8 @@ function deriveStageStates(events: SSEEvent[]): {
         break;
       }
 
-      case "s1_progress": {
+      case "s1_progress":
+      case "s1_video_skipped": {
         const completed = d.completed as number;
         const total = d.total as number;
         stages.S1_MAP = {
@@ -460,6 +461,8 @@ function formatEventLabel(evt: SSEEvent): { label: string; detail: string; color
       return { label: "S1 Analyze", detail: `started ${d.video_id}`, color: "var(--disc-a)" };
     case "s1_progress":
       return { label: "S1 Analyze", detail: `${d.video_id} → ${d.hook_type || "done"} (${d.completed}/${d.total})`, color: "var(--disc-a)" };
+    case "s1_video_skipped":
+      return { label: "S1 Analyze", detail: `⚠ skipped ${d.video_id} (${d.completed}/${d.total}) — ${(d.reason as string || "").slice(0, 80)}`, color: "var(--color-error)" };
     case "s2_complete":
       return { label: "S2 Aggregate complete", detail: `${d.pattern_count} patterns`, color: "var(--disc-a)" };
     case "s3_progress":

--- a/frontend/src/components/S1DiscoverGrid.tsx
+++ b/frontend/src/components/S1DiscoverGrid.tsx
@@ -10,13 +10,14 @@ import { useMemo } from "react";
 import { motion } from "framer-motion";
 import type { SSEEvent } from "../lib/sse-client";
 
-type CardState = "pending" | "processing" | "completed";
+type CardState = "pending" | "processing" | "completed" | "skipped";
 
 interface VideoCardData {
   videoId: string;
   index: number;
   state: CardState;
   description?: string;
+  skipReason?: string;
 }
 
 function deriveVideoStates(events: SSEEvent[], totalVideos: number): VideoCardData[] {
@@ -50,6 +51,21 @@ function deriveVideoStates(events: SSEEvent[], totalVideos: number): VideoCardDa
         index: videoOrder.indexOf(vid),
         state: "completed",
         description: existing?.description,
+      });
+    }
+
+    if (evt.event === "s1_video_skipped") {
+      const vid = d.video_id as string;
+      if (!cards.has(vid)) {
+        videoOrder.push(vid);
+      }
+      const existing = cards.get(vid);
+      cards.set(vid, {
+        videoId: vid,
+        index: videoOrder.indexOf(vid),
+        state: "skipped",
+        description: existing?.description,
+        skipReason: (d.reason as string) || undefined,
       });
     }
   }
@@ -100,6 +116,26 @@ function VideoCard({ card }: { card: VideoCardData }) {
     );
   }
 
+  if (card.state === "skipped") {
+    return (
+      <motion.div
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ type: "spring", stiffness: 500, damping: 30 }}
+        className="aspect-square rounded-md flex items-center justify-center cursor-default border-2 border-[var(--color-error)] bg-[var(--color-error)]/10"
+        title={
+          card.skipReason
+            ? `${card.videoId} — skipped: ${card.skipReason.slice(0, 120)}`
+            : `${card.videoId} — skipped`
+        }
+      >
+        <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="var(--color-error)">
+          <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+        </svg>
+      </motion.div>
+    );
+  }
+
   return (
     <motion.div
       initial={{ scale: 0.8, opacity: 0 }}
@@ -125,6 +161,8 @@ export default function S1DiscoverGrid({ events, totalVideos }: S1DiscoverGridPr
 
   const processing = cards.filter((c) => c.state === "processing").length;
   const completed = cards.filter((c) => c.state === "completed").length;
+  const skipped = cards.filter((c) => c.state === "skipped").length;
+  const processed = completed + skipped;
 
   return (
     <div className="space-y-3">
@@ -135,7 +173,12 @@ export default function S1DiscoverGrid({ events, totalVideos }: S1DiscoverGridPr
             Analyzing {totalVideos} videos
           </span>
           <span className="font-mono text-[11px] text-[var(--color-text)]">
-            {completed}/{totalVideos}
+            {processed}/{totalVideos}
+            {skipped > 0 && (
+              <span className="ml-2 text-[var(--color-error)]">
+                ({skipped} skipped)
+              </span>
+            )}
           </span>
         </div>
         {processing > 0 && (


### PR DESCRIPTION
## The bug
You hit it live: video \`7519194924265311502\` ("Ishowspeed vs daniel labelle" — a silent race clip with just hashtags) couldn't produce a valid S1Pattern no matter how many times the LLM retried. After Celery exhausted \`max_retries=3\` on top of the provider's internal \`MAX_RETRIES=3\`, \`_report_failure\` set the **whole pipeline** to \`failed\`. 99 successful video analyses → discarded.

## Fix: skip-and-continue

\`s1_analyze_task\` now distinguishes two failure modes:

| Failure | Action |
|---|---|
| \`MaxRetriesExceededError\` on ProviderError (schema drift, 429 storms) | **Skip** — mark this one video \`skipped\`, keep the run alive |
| Top-level \`StageError\` (parser problems, pydantic on the orchestrator result) | **Skip** |
| Unexpected \`Exception\` | Still **halt** — we don't know if it's recoverable |

\`Orchestrator.on_s1_skipped(run_id, video_id, reason)\`:
- \`INCR run:{id}:s1:done\` — skipped still counts toward the threshold
- \`XADD s1_video_skipped\` event with \`{video_id, reason, completed, total}\`
- \`if done >= num_videos\`: transition to S2 with whatever patterns succeeded

So S2 aggregates from 99 patterns instead of refusing to run at all.

## Frontend

- Grid card gets a fourth state: **skipped** — red-bordered tile with an X icon. Tooltip shows the skip reason (truncated).
- Progress readout: \`99/100 (1 skipped)\` in a red suffix when any were skipped.
- Activity log: \`⚠ skipped {video_id} — {reason}\` in error color.

## Tests

Two new orchestrator tests (116 passing, +2):
- \`test_on_s1_skipped_still_transitions_to_s2\` — 2 completes + 1 skip fires S2 dispatch
- \`test_on_s1_skipped_emits_event\` — event shape is correct, counter matches

ruff clean, astro check clean (0/0/0).

## What this does NOT fix
- LLMs still drift on sparse-content videos. PRs #2 (prompt hardening) and #3 (schema defaults) will reduce *how often* we have to skip. Together the three PRs handle different layers: **prompt** (prevent bad output), **schema** (accept reasonable output), **task** (survive the occasional bad output anyway).

## Test plan
- [x] \`ruff check .\` clean
- [x] 116 backend tests pass
- [x] \`astro check\` clean
- [ ] Post-deploy: trigger a run, confirm the sparse-content video renders as a red-X tile and the pipeline completes to S2 + beyond

🤖 Generated with [Claude Code](https://claude.com/claude-code)