### PR TITLE
feat: harden S1 prompt against sparse-content videos

### DIFF
--- a/backend/app/pipeline/prompts/s1_prompts.py
+++ b/backend/app/pipeline/prompts/s1_prompts.py
@@ -21,8 +21,21 @@ S1_ANALYZE_PROMPT = """You are a short-form video content analyst. Analyze this 
 - Do NOT mention specific sounds, dances, memes, challenges, hashtags, or trends
 - Focus on the STRUCTURE that makes this video work, not the specific CONTENT
 
+## When Information Is Sparse
+Videos sometimes arrive with no transcript, or just a few hashtags in
+the description. DO NOT refuse, DO NOT return a partial object, DO NOT
+omit fields. Instead:
+- Infer the most likely hook_type, pacing, and emotional_arc from
+  whatever signal you have (hashtags, emojis, engagement numbers,
+  description tone). A confident guess is fine.
+- For list fields with no evidence, return an empty list `[]`.
+- For `structure_notes`, say so explicitly — "sparse signal; inferring
+  from hashtags" — rather than returning nothing.
+The schema is not negotiable: every field below must appear in your
+response, every time.
+
 ## Output Format
-Respond with ONLY a JSON object:
+Respond with ONLY a JSON object containing EVERY field below:
 {{
     "video_id": "{video_id}",
     "hook_type": "...",


### PR DESCRIPTION
## The class of failure
Some videos in the Tsinghua/Kuaishou dataset arrive with **no transcript** and just a few hashtags in the description — the notorious \`Ishowspeed vs daniel labelle #clips\` case from yesterday's debug session, a silent race clip. The LLM reacted by returning a partial object missing \`hook_type\`, \`pacing\`, \`pattern_interrupts\`, \`structure_notes\` — which then failed schema validation downstream.

## Fix: tell the LLM what to do when information is thin
New section in \`S1_ANALYZE_PROMPT\`:

> **When Information Is Sparse**
> Videos sometimes arrive with no transcript, or just a few hashtags in the description. DO NOT refuse, DO NOT return a partial object, DO NOT omit fields. Instead:
> - Infer the most likely hook_type, pacing, and emotional_arc from whatever signal you have (hashtags, emojis, engagement numbers, description tone). **A confident guess is fine.**
> - For list fields with no evidence, return an empty list \`[]\`.
> - For \`structure_notes\`, say so explicitly — "sparse signal; inferring from hashtags" — rather than returning nothing.
> **The schema is not negotiable: every field below must appear in your response, every time.**

Also emphasized "EVERY field below" in the output-format instruction.

## Why this pairs with the other PRs
Three layers defend against the same failure mode:

| PR | Layer | Role |
|---|---|---|
| **This** | Prompt | **Prevent** bad output — tell the LLM what to do when stuck |
| #157 (pending) | Schema | **Accept** reasonable output — defaults for list fields |
| #156 | Task | **Survive** bad output anyway — skip-and-continue |

Each alone reduces breakage; together they make S1 robust to dataset diversity.

## Test plan
- [x] \`ruff check .\` clean
- [x] 114 tests pass (prompt-only change, no code behavior affected)
- [ ] Post-deploy: retry the Ishowspeed video that broke yesterday, confirm it produces a valid schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)