### PR TITLE
refactor: loosen S1Pattern — list fields default to [] on omission

### DIFF
--- a/backend/app/models/stages.py
+++ b/backend/app/models/stages.py
@@ -14,14 +14,19 @@ class VideoInput(BaseModel):
 
 
 class S1Pattern(BaseModel):
+    # Core identifiers + classifications — required. S2 aggregation keys
+    # off hook_type + pacing, so these must be present.
     video_id: str
     hook_type: str
     pacing: str
-    emotional_arc: str
-    pattern_interrupts: list[str]
-    retention_mechanics: list[str]
-    engagement_triggers: list[str]
-    structure_notes: str
+    emotional_arc: str = ""
+    # Descriptive lists — default to [] so the LLM can omit them on
+    # sparse-content videos without failing validation. Prompt still asks
+    # for them; this is a safety net.
+    pattern_interrupts: list[str] = []
+    retention_mechanics: list[str] = []
+    engagement_triggers: list[str] = []
+    structure_notes: str = ""
 
 
 class PatternEntry(BaseModel):


### PR DESCRIPTION
## Safety net for sparse-content videos
Same failure class as #156 (skip-and-continue) and #157 (prompt hardening): the LLM sometimes omits descriptive list fields on videos with no transcript. Previously those omissions triggered a pydantic \`ValidationError\` that — before #156 — killed the whole pipeline. Even after #156, that video would be **skipped** unnecessarily when we could have just accepted the missing optional fields.

## Before / after

**Before** (every field required):
\`\`\`python
class S1Pattern(BaseModel):
    video_id: str
    hook_type: str
    pacing: str
    emotional_arc: str
    pattern_interrupts: list[str]
    retention_mechanics: list[str]
    engagement_triggers: list[str]
    structure_notes: str
\`\`\`

**After** (required core, defaulted descriptors):
\`\`\`python
class S1Pattern(BaseModel):
    # Core — S2 aggregation keys on these, so they must be present
    video_id: str
    hook_type: str
    pacing: str
    emotional_arc: str = ""
    # Descriptive lists — safety net for LLM omission
    pattern_interrupts: list[str] = []
    retention_mechanics: list[str] = []
    engagement_triggers: list[str] = []
    structure_notes: str = ""
\`\`\`

## Why this is safe

\`S2\` aggregation ([s2_aggregate.py](backend/app/pipeline/stages/s2_aggregate.py)) computes the pattern library by grouping on \`hook_type + pacing\` — those two fields are what the whole rest of the pipeline keys off. The descriptive lists are informational and aren't consumed by downstream stages (S3 through S6 never read them).

The prompt (#157) still asks for every field, so a healthy LLM response still fills everything in. These defaults only activate as a **safety net** when the model hedges on the descriptive parts of an information-sparse video.

## The three-PR defense in depth

| PR | Layer | Role on a sparse-content video |
|---|---|---|
| #157 | Prompt | **Prevent** hedging — explicit instructions to always emit the schema |
| **This (#158)** | Schema | **Accept** reasonable output — defaults absorb LLM hedges gracefully |
| #156 | Task | **Survive** total LLM failure — skip the one bad video |

Each alone helps; together they should reduce skip rate to near-zero while still surviving pathological cases.

## Test plan
- [x] \`ruff check .\` clean
- [x] 114 tests pass — existing S1 tests all pass because real LLM responses populate every field, same as before
- [ ] Post-deploy: the Ishowspeed-style sparse video should now validate with hook_type + pacing only, even if the LLM omits the lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)