### PR TITLE
ci: run terraform apply + pin task-def family in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
+      - "terraform/**"
+      - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
 env:
@@ -17,11 +19,15 @@ env:
   ECS_API_SERVICE: flair2-dev-api
   ECS_WORKER_SERVICE: flair2-dev-worker
   FRONTEND_S3_BUCKET: flair2-dev-frontend
+  TF_VERSION: "1.9.0"
+  TF_WORKING_DIR: terraform
+  TF_VAR_FILE: environments/dev.tfvars
 
 jobs:
-  # ── Backend ────────────────────────────────────────────────────────────────
-  deploy-backend:
-    name: Backend — Docker → ECR → ECS
+  # ── Build Docker image + push to ECR ──────────────────────────────────────
+  # Runs in parallel with terraform. Deploy waits for both.
+  build-backend:
+    name: Build — Docker → ECR
     runs-on: ubuntu-latest
 
     steps:
@@ -53,18 +59,71 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_WORKER_REPO:${{ github.sha }}
           docker push $ECR_REGISTRY/$ECR_WORKER_REPO:latest
 
-      - name: Deploy to ECS
+  # ── Terraform apply ───────────────────────────────────────────────────────
+  # Creates new task definition revisions when the terraform source changes
+  # (e.g. Celery command, CPU/memory sizing, env vars). Idempotent — a no-op
+  # on pure code PRs, ~15-30s. Runs in parallel with build-backend.
+  terraform:
+    name: Infra — terraform apply
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init -input=false
+
+      - name: Terraform apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform apply -auto-approve -input=false -var-file=${{ env.TF_VAR_FILE }}
+
+  # ── Deploy to ECS ─────────────────────────────────────────────────────────
+  # Waits for BOTH the new image (from build) and the new task definition
+  # revision (from terraform) to exist before rolling the ECS services.
+  # Using --task-definition <family> (no :revision) tells ECS to use the
+  # latest ACTIVE revision — the one terraform just minted.
+  deploy-backend:
+    name: Deploy — roll ECS services
+    runs-on: ubuntu-latest
+    needs: [build-backend, terraform]
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update API service (latest task def + force new deployment)
         run: |
           aws ecs update-service \
             --cluster $ECS_CLUSTER \
             --service $ECS_API_SERVICE \
+            --task-definition $ECS_API_SERVICE \
             --force-new-deployment \
             --region $AWS_REGION \
             --no-cli-pager
 
+      - name: Update worker service (latest task def + force new deployment)
+        run: |
           aws ecs update-service \
             --cluster $ECS_CLUSTER \
             --service $ECS_WORKER_SERVICE \
+            --task-definition $ECS_WORKER_SERVICE \
             --force-new-deployment \
             --region $AWS_REGION \
             --no-cli-pager
@@ -85,7 +144,7 @@ jobs:
 
           echo "Backend deploy complete."
 
-  # ── Frontend ───────────────────────────────────────────────────────────────
+  # ── Frontend ──────────────────────────────────────────────────────────────
   deploy-frontend:
     name: Frontend — Build → S3
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
Two related fixes to the deploy pipeline — both needed to close the "we merged the terraform change but the running workers don't reflect it" loop we hit yesterday on #152.

## What changed

### 1. New terraform job, runs parallel to build
\`\`\`
build-backend ─┐
               ├─→ deploy-backend
terraform     ─┘
\`\`\`

\`terraform apply -auto-approve\` runs on every deploy-trigger push. When terraform source hasn't changed, it's a ~15–30s no-op. When it has, it mints a new task-definition revision BEFORE deploy-backend runs \`update-service\`.

Triggers extended to:
- \`terraform/**\` changes
- \`deploy.yml\` self-edits (so we can iterate on the workflow itself)

### 2. Pin \`--task-definition\` on update-service
Before:
\`\`\`bash
aws ecs update-service --service $ECS_WORKER_SERVICE --force-new-deployment
# ECS keeps using whatever revision was first set.
# The terraform-made revision sits unused.
\`\`\`

After:
\`\`\`bash
aws ecs update-service --service $ECS_WORKER_SERVICE \\
  --task-definition $ECS_WORKER_SERVICE \\
  --force-new-deployment
# Passing just the family name (no :revision) selects the latest ACTIVE
# revision — the one terraform just minted.
\`\`\`

Same change for both the API and worker services.

## The class of bug this kills
You merged #152 (\`--concurrency=4\` → \`--pool=threads --concurrency=20\`), Deploy ran green, but workers still came up at concurrency 4 because:
- Build re-pushed the image (no change to the command baked into the image — the command is a **task-definition override**, not a Dockerfile CMD)
- ECS \`update-service --force-new-deployment\` rolled tasks using the existing task def
- Terraform code on main had the new command, but the AWS state hadn't been updated

You ran \`terraform apply\` manually, but even then the service wasn't repointed at the new revision — because \`ignore_changes = [task_definition]\` on the service tells terraform not to touch that field after initial creation.

This PR closes the loop automatically.

## What it does NOT do
- Doesn't apply to staging/prod separately — dev.tfvars is hardcoded. If we ever split environments, add matrix strategy.
- Doesn't run \`terraform plan\` as a review gate on PRs. That would require a \`ci.yml\` change, separate discussion.
- Doesn't cache terraform providers between runs. ~5s per invocation, not worth optimizing yet.

## Test plan
- [ ] After merge: Deploy workflow runs three jobs — build, terraform, deploy. Deploy only starts after both parents finish.
- [ ] Terraform apply log should show \`No changes. Your infrastructure matches the configuration.\` on this PR (no infra changes in this PR itself).
- [ ] Once a terraform change lands on main (e.g. the next time we tune Celery concurrency), the deploy picks it up without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)