### PR TITLE
fix: SSE resume-on-remount via explicit ?cursor query param

### DIFF
--- a/backend/app/api/routes/pipeline.py
+++ b/backend/app/api/routes/pipeline.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import redis.asyncio as aioredis
 import structlog
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from sse_starlette.sse import EventSourceResponse
 
 from app.api.deps import get_redis, get_session_id
@@ -102,22 +102,29 @@ async def pipeline_status(
     request: Request,
     r: aioredis.Redis = Depends(get_redis),
     last_event_id: str | None = Header(None, alias="Last-Event-ID"),
+    cursor: str | None = Query(None),
 ) -> EventSourceResponse:
     """Stream pipeline events via SSE.
 
     Uses Redis Streams (XREAD) — multi-tab safe. Each connection
-    maintains its own cursor. On reconnect, the browser sends
-    Last-Event-ID as a header automatically.
+    maintains its own cursor. Resume semantics (highest priority first):
+
+      1. `?cursor=X` query param — explicit client-controlled resume
+         for fresh mounts where the browser has no prior Last-Event-ID
+         (SPA navigation back to the pipeline page).
+      2. `Last-Event-ID` header — sent automatically by native
+         EventSource on transient reconnects.
+      3. "0-0" — start from the beginning of the stream.
     """
     # Verify run exists
     status = await r.get(f"run:{run_id}:status")
     if status is None:
         raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
 
-    cursor = last_event_id or "0-0"
+    resume_from = cursor or last_event_id or "0-0"
 
     return EventSourceResponse(
-        sse_event_generator(r, run_id, cursor, request),
+        sse_event_generator(r, run_id, resume_from, request),
     )
 
 

--- a/frontend/src/lib/sse-client.ts
+++ b/frontend/src/lib/sse-client.ts
@@ -2,8 +2,18 @@
  * SSE client — React hook for pipeline event streaming.
  *
  * Opens an EventSource to /api/pipeline/status/{runId}.
- * Relies on the browser's native EventSource auto-reconnect which
- * preserves Last-Event-ID across retries.
+ *
+ * Resume semantics:
+ *   - Native EventSource auto-reconnects on transient network errors
+ *     and re-sends its own Last-Event-ID header. No extra work needed
+ *     for that path.
+ *   - For COMPONENT REMOUNT (SPA navigation back to the same runId,
+ *     or deliberate tab refocus on an in-flight run), the browser
+ *     drops its internal Last-Event-ID. We persist the last-seen ID
+ *     per-runId in a module-level Map and pass it as `?cursor=<id>`
+ *     on fresh EventSource connections. Backend prefers this over the
+ *     header.
+ *
  * Multi-tab safe (backend uses Redis Streams, not BLPOP).
  *
  * Contract: https://github.com/yangyang-how/flair2/issues/71 Section 2.
@@ -12,6 +22,11 @@
 import { useEffect, useRef, useState } from "react";
 
 const API_BASE = import.meta.env.PUBLIC_API_URL || "";
+
+// Cross-mount memory of last-seen event IDs. Lives for the lifetime of
+// the module (≈ the tab's JS runtime), which is the right scope for
+// "user navigated away and came back".
+const lastSeenByRunId: Map<string, string> = new Map();
 
 // ── Types ──────────────────────────────────────────────────
 
@@ -50,11 +65,21 @@ export function useSSE(runId: string | null): SSEState {
   useEffect(() => {
     if (!runId) return;
 
-    const url = `${API_BASE}/api/pipeline/status/${runId}`;
+    // If we've seen events for this runId in this session already,
+    // resume from the last one we got instead of replaying from "0-0".
+    const cursor = lastSeenByRunId.get(runId);
+    const url = cursor
+      ? `${API_BASE}/api/pipeline/status/${runId}?cursor=${encodeURIComponent(cursor)}`
+      : `${API_BASE}/api/pipeline/status/${runId}`;
     const es = new EventSource(url);
     eventSourceRef.current = es;
 
+    const recordId = (id: string) => {
+      if (id) lastSeenByRunId.set(runId, id);
+    };
+
     const pushEvent = (sseEvent: SSEEvent) => {
+      recordId(sseEvent.id);
       setState((prev) => ({
         ...prev,
         event: sseEvent,


### PR DESCRIPTION
## What works today
Native EventSource auto-reconnects on transient network errors and re-sends its own \`Last-Event-ID\` header. The backend \`/api/pipeline/status/{run_id}\` endpoint honors that header. That path already works — no change needed.

## What doesn't
**Component remount.** If you navigate away from the pipeline page and back to the same run in the same session, the browser drops its internal \`Last-Event-ID\` and the new \`EventSource\` starts from \`"0-0"\`. Redis Stream history is still intact so technically everything replays — but:
- If the stream is ever trimmed (not today; future concern), events vanish for remount viewers
- On an already-completed run, remount re-streams everything which is wasteful

Root cause: the \`EventSource\` API doesn't let you set headers, so the frontend has no way to say "resume from here" on a fresh connection.

## Fix
Two tiny, complementary changes.

### Backend — accept a \`?cursor=\` query param

\`\`\`python
@router.get("/api/pipeline/status/{run_id}")
async def pipeline_status(
    ...
    last_event_id: str | None = Header(None, alias="Last-Event-ID"),
    cursor: str | None = Query(None),
) -> EventSourceResponse:
    # Resume precedence:
    #   ?cursor=X (explicit client-controlled)
    #   Last-Event-ID header (native browser reconnect)
    #   "0-0"
    resume_from = cursor or last_event_id or "0-0"
    ...
\`\`\`

### Frontend — module-level per-runId cursor map

\`\`\`ts
const lastSeenByRunId: Map<string, string> = new Map();

// On every non-terminal event:
lastSeenByRunId.set(runId, sseEvent.id);

// On mount:
const cursor = lastSeenByRunId.get(runId);
const url = cursor
  ? \`/api/pipeline/status/\${runId}?cursor=\${encodeURIComponent(cursor)}\`
  : \`/api/pipeline/status/\${runId}\`;
\`\`\`

Terminal events (\`pipeline_complete\`, \`pipeline_error\`) deliberately do **not** update the cursor — so on remount for a completed run, we resume from the last progress event and still deliver the terminal, not stranded after it.

## Honest caveat
This is the right resume mechanism, but it's NOT a root-cause fix for the specific "99/100 with all tiles green" behavior you reported earlier. That screenshot showed a single-session anomaly where events should have arrived on the same connection. If you see it again after this deploys, it's a different bug — probably a race between \`s1_task_started\` and \`s1_progress\` rendering — and we'd need to diagnose separately.

## Test plan
- [x] \`ruff check .\` clean
- [x] 114 backend tests pass
- [x] \`astro check\` clean (0/0/0)
- [ ] After deploy: start a pipeline, let it run to S3, navigate to Runs and back to the same pipeline. All prior events replay once, then live events continue. No duplicate rendering.
- [ ] Second test: let a pipeline complete, then navigate to Runs → back to its /pipeline/ view. Final state renders immediately, no blank grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)