### PR TITLE
feat: one-click destroy workflow for dev infrastructure

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,0 +1,95 @@
+name: Destroy Infra
+
+# Tears down the dev environment via `terraform destroy`. Manual-only
+# trigger with a typed-confirmation gate — this is not a button you
+# want to click accidentally.
+#
+# After a successful destroy, re-deploy by either:
+#   - running this same repo's Deploy workflow (workflow_dispatch), or
+#   - pushing any backend/frontend/terraform change to main
+# Both will re-run `terraform apply` which rebuilds the full stack.
+#
+# What this DOES destroy:
+#   ECS cluster + API/worker services + task definitions
+#   ALB + target groups + listeners
+#   ElastiCache Redis node (data is lost — it's a cache, not a DB)
+#   VPC + subnets + security groups
+#   ECR repositories (images included — force_delete=true)
+#   CloudWatch log groups
+#   IAM roles/policies that terraform owns
+#
+# What this DOES NOT destroy:
+#   The Kimi API key in Secrets Manager (imported, not terraform-owned)
+#   The frontend S3 bucket contents (terraform doesn't manage the bucket
+#     objects; bucket itself IS managed if terraform owns it — check
+#     terraform plan output first if you're unsure)
+#   The terraform state bucket (separate from the infra it tracks)
+#   Dynamo tables if they hold performance data you want to keep
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type DESTROY (uppercase) to confirm teardown of the dev environment'
+        required: true
+        type: string
+
+env:
+  AWS_REGION: us-west-2
+  TF_VERSION: "1.9.0"
+  TF_WORKING_DIR: terraform
+  TF_VAR_FILE: environments/dev.tfvars
+
+jobs:
+  destroy:
+    name: terraform destroy
+    runs-on: ubuntu-latest
+    # Guard 1: confirmation input must match exactly
+    if: ${{ github.event.inputs.confirm == 'DESTROY' }}
+    # Guard 2: only runnable from main branch
+    # (workflow_dispatch can be triggered from any ref; this pins it)
+
+    steps:
+      - name: Reject non-main triggers
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "::error::Destroy must be triggered from main branch, not ${{ github.ref }}"
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init -input=false
+
+      - name: Terraform plan (destroy)
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform plan -destroy \
+            -input=false \
+            -var-file=${{ env.TF_VAR_FILE }} \
+            -out=destroy.tfplan
+
+      - name: Terraform destroy
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        # Saved plan files carry their own approval — no -auto-approve needed
+        run: terraform apply -input=false destroy.tfplan
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Destroy complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Bring the stack back by running the Deploy workflow or pushing to main." >> $GITHUB_STEP_SUMMARY

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -9,6 +9,11 @@ resource "aws_ecr_repository" "api" {
   name                 = "${local.prefix}-api"
   image_tag_mutability = "MUTABLE"
 
+  # Allow `terraform destroy` to delete this repo even when images
+  # are still inside. Lifecycle policy already caps at 10 images;
+  # this just removes the "repo not empty" guardrail on teardown.
+  force_delete = true
+
   image_scanning_configuration {
     scan_on_push = true
   }
@@ -22,6 +27,10 @@ resource "aws_ecr_repository" "api" {
 resource "aws_ecr_repository" "worker" {
   name                 = "${local.prefix}-worker"
   image_tag_mutability = "MUTABLE"
+
+  # Allow `terraform destroy` to delete this repo even when images
+  # are still inside.
+  force_delete = true
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
## What it is
Manual-trigger GitHub Action that runs \`terraform destroy\` against dev. For quick teardown when you're done testing or want to stop burning Fargate/ElastiCache hours.

**Trigger**: Actions tab → "Destroy Infra" → "Run workflow" → type \`DESTROY\` → Run.

## Safety gates

1. **Typed confirmation** — input must be exactly \`DESTROY\` (uppercase). Workflow step is gated by \`if: github.event.inputs.confirm == 'DESTROY'\`. Empty string or typo → workflow runs but does nothing.
2. **Main-only** — explicit check at the top: \`refuse if github.ref != 'refs/heads/main'\`. Prevents anyone from triggering destroy against a branch with different terraform state expectations.
3. **Save-plan-then-apply pattern**:
   \`\`\`
   terraform plan -destroy -out=destroy.tfplan
   terraform apply destroy.tfplan
   \`\`\`
   The saved plan carries its own approval, and the apply step executes **exactly what the plan showed** — no surprise moves between the two steps. Plan output is visible in the workflow log.

## Small terraform change: \`force_delete = true\` on ECR repos

Without this, \`terraform destroy\` aborts at the first non-empty repo ("repository contains images"). We'd have to \`aws ecr batch-delete-image\` first, clumsy. Lifecycle policy already caps images at 10, so setting force_delete doesn't change day-to-day behavior — only affects teardown.

## What gets destroyed

| Resource | Destroyed? |
|---|---|
| ECS cluster, services, task definitions | yes |
| ALB + target groups + listeners | yes |
| ElastiCache Redis (data is cache, not DB) | yes |
| VPC, subnets, security groups | yes |
| ECR repos (with images via force_delete) | yes |
| CloudWatch log groups | yes |
| IAM roles/policies terraform owns | yes |
| Kimi API key in Secrets Manager | **no** (imported, not terraform-owned) |
| Terraform state S3 bucket | **no** (separate from the infra it tracks) |

## Bring-back
Existing Deploy workflow handles it — push anything to main or run Deploy manually. Once #159 is merged, the terraform job auto-runs and recreates the whole stack. ~10 minutes end-to-end.

## Runtime
\`terraform destroy\` on this stack usually takes **8–12 minutes**:
- ECS service drain: 2–5 min (graceful task stop)
- ALB deletion: 2–3 min
- VPC + dependencies: 2–3 min
GitHub Actions default 6-hour job timeout, plenty.

## Test plan
- [ ] After merge: Actions tab shows a "Destroy Infra" workflow. Clicking it requires the \`confirm\` input.
- [ ] Typing anything other than \`DESTROY\` → workflow runs but the destroy job is skipped.
- [ ] Typing \`DESTROY\` → plan shows all resources being destroyed, apply executes.
- [ ] Post-destroy: next push to main → terraform job recreates everything, deploy rolls new tasks, app works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)