### PR TITLE
feat: bias S3 script generation by creator niche

### DIFF
--- a/backend/app/pipeline/prompts/s3_prompts.py
+++ b/backend/app/pipeline/prompts/s3_prompts.py
@@ -6,7 +6,7 @@ S3_GENERATE_PROMPT = """You are a viral short-form video scriptwriter. Generate 
 ## Pattern Library Context
 These are the most common structural patterns found in high-engagement videos:
 {pattern_library_summary}
-
+{creator_context}
 {feedback_section}
 
 ## Requirements
@@ -15,7 +15,7 @@ These are the most common structural patterns found in high-engagement videos:
 - The script must have three parts: hook, body, payoff
 - Focus on STRUCTURAL effectiveness, not trend-chasing
 - The hook must capture attention in the first 3 seconds
-- Include at least one pattern interrupt to maintain retention
+- Include at least one pattern interrupt to maintain retention{niche_instruction}
 
 ## Output Format
 Respond with ONLY a JSON object:

--- a/backend/app/pipeline/stages/s3_generate.py
+++ b/backend/app/pipeline/stages/s3_generate.py
@@ -9,6 +9,7 @@ import structlog
 from app.config import settings
 from app.models.errors import StageError
 from app.models.performance import VideoPerformance
+from app.models.pipeline import CreatorProfile
 from app.models.stages import CandidateScript, PatternEntry, S2PatternLibrary
 from app.pipeline.prompts.s3_prompts import S3_FEEDBACK_SECTION, S3_GENERATE_PROMPT
 from app.providers.base import ReasoningProvider
@@ -35,6 +36,42 @@ def _pattern_library_summary(library: S2PatternLibrary) -> str:
     return "\n".join(lines)
 
 
+def _build_creator_context(profile: CreatorProfile | None) -> str:
+    """Inject creator niche/themes so generated scripts are on-topic.
+
+    Without this, S3 produces generic viral scripts whose topic reflects
+    the analyzed video dataset (random TikTok content). S6 can then only
+    adjust voice — not subject matter. Anchoring S3 to the creator's
+    niche fixes the "Kitchen Confident got a productivity script" bug.
+    """
+    if not profile:
+        return ""
+    lines = []
+    if profile.niche:
+        lines.append(f"Niche: {profile.niche}")
+    if profile.audience_description:
+        lines.append(f"Target audience: {profile.audience_description}")
+    if profile.content_themes:
+        lines.append(f"Content themes: {', '.join(profile.content_themes)}")
+    if profile.example_hooks:
+        lines.append(f"Example hooks that worked: {' | '.join(profile.example_hooks[:3])}")
+    if profile.recent_topics:
+        lines.append(f"Recently covered (avoid repeating): {', '.join(profile.recent_topics)}")
+    if not lines:
+        return ""
+    return "\n## Creator Context\n" + "\n".join(lines) + "\n"
+
+
+def _niche_instruction(profile: CreatorProfile | None) -> str:
+    if not profile or not profile.niche:
+        return ""
+    return (
+        f"\n- **CRITICAL**: Ground the script in the creator's niche ({profile.niche}). "
+        "The hook, body, and payoff must all be on-topic for this niche. "
+        "Use the structural pattern to shape HOW the story is told, not WHAT the story is about."
+    )
+
+
 def _assign_patterns(library: S2PatternLibrary, target: int) -> list[PatternEntry]:
     total_freq = sum(p.frequency for p in library.patterns) or 1
     assignments: list[PatternEntry] = []
@@ -55,11 +92,14 @@ async def s3_generate(
     feedback: list[VideoPerformance] | None = None,
     num_scripts: int | None = None,
     slot_factory: Callable[[], AbstractAsyncContextManager[None]] | None = None,
+    creator_profile: CreatorProfile | None = None,
 ) -> list[CandidateScript]:
     """Generate candidate scripts concurrently, one LLM call per script."""
     target = num_scripts or settings.s3_script_count
     feedback_section = _build_feedback_section(feedback)
     library_summary = _pattern_library_summary(library)
+    creator_context = _build_creator_context(creator_profile)
+    niche_instruction = _niche_instruction(creator_profile)
     assignments = _assign_patterns(library, target)
 
     async def _generate_one(pattern: PatternEntry) -> CandidateScript | None:
@@ -67,6 +107,8 @@ async def s3_generate(
             pattern_type=pattern.pattern_type,
             pattern_library_summary=library_summary,
             feedback_section=feedback_section,
+            creator_context=creator_context,
+            niche_instruction=niche_instruction,
         )
         slot = slot_factory() if slot_factory is not None else nullcontext()
         async with slot:

--- a/backend/app/workers/tasks.py
+++ b/backend/app/workers/tasks.py
@@ -244,6 +244,7 @@ def s3_generate_task(self, run_id: str):
                 provider,
                 num_scripts=config.num_scripts,
                 slot_factory=_slot_factory,
+                creator_profile=config.creator_profile,
             )
             await redis.set(
                 f"scripts:candidates:{run_id}",


### PR DESCRIPTION
## Problem
The creator profile only affected S6. S3 generated scripts from random viral patterns in the dataset — topic locked in. S6 could only adjust voice/vocabulary, not subject. Kitchen Confident creator received productivity scripts that were personalized with cooking vocabulary but were still about productivity.

## Fix
Inject creator niche + themes + audience + recent topics into the S3 prompt. A CRITICAL instruction tells the LLM: "use the structural pattern to shape HOW the story is told, not WHAT it is about."

## Changes
- \`s3_prompts.py\` — add \`{creator_context}\` and \`{niche_instruction}\` placeholders
- \`s3_generate.py\` — \`_build_creator_context()\` and \`_niche_instruction()\` helpers, new \`creator_profile\` param
- \`tasks.py\` — pass \`config.creator_profile\` through to \`s3_generate\`

## Test plan
- [x] 111 unit tests pass, lint clean
- [ ] Deploy and run a pipeline with Kitchen Confident → scripts should be about cooking/weeknight meals
- [ ] Run with different profiles to confirm the pipeline respects niche

🤖 Generated with [Claude Code](https://claude.com/claude-code)