### PR TITLE
feat: transition at 95% completion to skip stragglers

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,6 +43,14 @@ class Settings(BaseSettings):
     s4_persona_count: int = 42
     s6_top_n: int = 10
 
+    # Completion thresholds — transition to next stage when this fraction
+    # of fan-out tasks finished (completed or skipped). Prevents one
+    # rate-limited straggler (~10min retry budget) from blocking the
+    # whole run behind itself. Late completers still INCR counters; the
+    # SETNX guard in the orchestrator ensures the transition fires once.
+    s1_completion_threshold: float = 0.95
+    s4_completion_threshold: float = 0.95
+
     # Celery (db=1 — separate from state Redis)
     celery_broker_url: str = "redis://localhost:6379/1"
 

--- a/backend/app/pipeline/orchestrator.py
+++ b/backend/app/pipeline/orchestrator.py
@@ -13,6 +13,7 @@ Follows interface contract #71 v3 exactly:
 """
 
 import json
+import math
 from datetime import UTC, datetime
 
 import structlog
@@ -69,9 +70,57 @@ class Orchestrator:
     async def emit_event(self, run_id: str, event: str, data: dict) -> None:
         await self._xadd_event(run_id, event, data)
 
+    async def _try_transition(
+        self,
+        run_id: str,
+        stage_key: str,
+        done: int,
+        total: int,
+        threshold: float,
+        transition: "callable",
+    ) -> None:
+        """Trigger the next-stage transition at most once, when enough tasks
+        have finished.
+
+        Uses SETNX on a per-stage flag to guarantee exactly-once dispatch
+        even when multiple concurrent completions all cross the threshold
+        line within the same millisecond window.
+
+        threshold is a fraction of `total`. 1.0 means "wait for everyone",
+        0.95 means "good enough at 95 of 100 — late ones keep running but
+        we move on".
+        """
+        from app.config import settings as _settings  # local: avoid cycle
+
+        # ceil so that threshold=0.95 × 10 items requires 10 completions
+        # (not 9 — int() would truncate). Threshold only kicks in for
+        # large fan-outs where saving the last 5% actually matters.
+        needed = max(1, math.ceil(total * threshold))
+        if done < needed and done < total:
+            return
+
+        triggered = await self._r.setnx(
+            f"run:{run_id}:{stage_key}:triggered", "1", ttl=TTL_SECONDS,
+        )
+        if not triggered:
+            return  # another completion already fired the transition
+        logger.info(
+            "orchestrator_transition_triggered",
+            run_id=run_id,
+            stage=stage_key,
+            done=done,
+            total=total,
+            threshold=threshold,
+            early=(done < total),
+        )
+        _ = _settings  # silence unused if not needed; helper imports for future use
+        await transition()
+
     async def on_s1_complete(
         self, run_id: str, video_id: str, pattern_summary: dict | None = None,
     ) -> None:
+        from app.config import settings as _settings
+
         done = await self._r.incr(f"run:{run_id}:s1:done")
         config = await self._load_config(run_id)
 
@@ -85,8 +134,11 @@ class Orchestrator:
 
         await self._xadd_event(run_id, "s1_progress", event_data)
 
-        if done >= config.num_videos:
-            await self._transition_s2(run_id)
+        await self._try_transition(
+            run_id, "s2", done, config.num_videos,
+            _settings.s1_completion_threshold,
+            lambda: self._transition_s2(run_id),
+        )
 
     async def on_s1_skipped(
         self, run_id: str, video_id: str, reason: str,
@@ -113,8 +165,12 @@ class Orchestrator:
             reason=reason[:200],
         )
 
-        if done >= config.num_videos:
-            await self._transition_s2(run_id)
+        from app.config import settings as _settings
+        await self._try_transition(
+            run_id, "s2", done, config.num_videos,
+            _settings.s1_completion_threshold,
+            lambda: self._transition_s2(run_id),
+        )
 
     async def on_s2_complete(self, run_id: str, pattern_count: int = 0) -> None:
         await self._xadd_event(run_id, "s2_complete", {"pattern_count": pattern_count})
@@ -154,8 +210,12 @@ class Orchestrator:
             "total": config.num_personas,
         })
 
-        if done >= config.num_personas:
-            await self._transition_s5(run_id)
+        from app.config import settings as _settings
+        await self._try_transition(
+            run_id, "s5", done, config.num_personas,
+            _settings.s4_completion_threshold,
+            lambda: self._transition_s5(run_id),
+        )
 
     async def recover(self, run_id: str) -> None:
         """Resume a crashed run from the last S4 checkpoint.

--- a/backend/tests/unit/test_orchestrator.py
+++ b/backend/tests/unit/test_orchestrator.py
@@ -184,6 +184,44 @@ async def test_on_s1_skipped_emits_event(redis, config, videos):
     assert skipped[0]["data"]["total"] == 3
 
 
+async def test_s1_threshold_transitions_early_on_large_fanout(redis, config):
+    """With 100 videos and 0.95 threshold, S2 fires at 95 — stragglers don't block."""
+    from app.models.pipeline import CreatorProfile, PipelineConfig
+
+    big_config = PipelineConfig(
+        run_id="big", session_id="s", reasoning_model="kimi", video_model=None,
+        creator_profile=CreatorProfile(
+            tone="casual", vocabulary=[], catchphrases=[], topics_to_avoid=[],
+        ),
+        num_videos=100, num_scripts=5, num_personas=2, top_n=2,
+    )
+    big_videos = [
+        VideoInput(video_id=f"v{i}", transcript=None, description=None,
+                   duration=30.0, engagement={})
+        for i in range(100)
+    ]
+    with patch("app.workers.tasks.s1_analyze_task") as mock_task:
+        mock_task.delay = MagicMock()
+        await Orchestrator(redis).start("big-run", big_config, big_videos)
+
+    with patch("app.workers.tasks.s2_aggregate_task") as mock_s2:
+        mock_s2.delay = MagicMock()
+        orch = Orchestrator(redis)
+        # First 94 completions don't transition
+        for i in range(94):
+            await orch.on_s1_complete("big-run", f"v{i}")
+        mock_s2.delay.assert_not_called()
+
+        # 95th crosses ceil(100 * 0.95) = 95 threshold → S2 fires once
+        await orch.on_s1_complete("big-run", "v94")
+        mock_s2.delay.assert_called_once_with("big-run")
+
+        # Remaining 5 completions don't re-trigger (SETNX guard)
+        for i in range(95, 100):
+            await orch.on_s1_complete("big-run", f"v{i}")
+        mock_s2.delay.assert_called_once()
+
+
 async def test_s1_complete_transitions_stage(redis, config, videos):
     with patch("app.workers.tasks.s1_analyze_task") as mock_task:
         mock_task.delay = MagicMock()


### PR DESCRIPTION
## Problem
With PR #164's generous rate-limit retry budget (~10min per task), a single straggler can block the whole pipeline behind itself. At 99/100 videos done, the UI shows "Pipeline appears stalled" while one task retries rate limits for minutes.

## Fix
Transition S1→S2 (and S4→S5) when 95% of fan-out tasks complete. Stragglers keep running but don't gate the next stage.

- \`s1_completion_threshold = 0.95\` and \`s4_completion_threshold = 0.95\` (config)
- \`_try_transition\` helper with SETNX guard on \`run:{id}:{stage}:triggered\` for exactly-once dispatch
- \`math.ceil\` (not \`int\`) so small runs still wait for all tasks: ceil(3 × 0.95) = 3

## Test plan
- [x] 13/13 orchestrator tests pass including new threshold test
- [x] Lint clean
- [ ] Deploy → 100-video runs should complete even with a few stragglers

🤖 Generated with [Claude Code](https://claude.com/claude-code)