### PR TITLE
feat: show persona bio in S4 vote matrix

### DIFF
--- a/backend/app/pipeline/orchestrator.py
+++ b/backend/app/pipeline/orchestrator.py
@@ -195,6 +195,7 @@ class Orchestrator:
         persona_id: str,
         top_5: list[str] | None = None,
         persona_name: str | None = None,
+        persona_description: str | None = None,
     ) -> None:
         done = await self._r.incr(f"run:{run_id}:s4:done")
         config = await self._load_config(run_id)
@@ -202,13 +203,17 @@ class Orchestrator:
         # Checkpoint: persist progress so crash recovery can resume from here
         await self._r.write_checkpoint(run_id, "s4", done)
 
-        await self._xadd_event(run_id, "vote_cast", {
+        event_data: dict = {
             "persona_id": persona_id,
             "persona_name": persona_name or persona_id,
             "top_5": top_5 or [],
             "completed": done,
             "total": config.num_personas,
-        })
+        }
+        if persona_description:
+            event_data["persona_description"] = persona_description
+
+        await self._xadd_event(run_id, "vote_cast", event_data)
 
         from app.config import settings as _settings
         await self._try_transition(

--- a/backend/app/workers/tasks.py
+++ b/backend/app/workers/tasks.py
@@ -305,13 +305,16 @@ def s4_vote_task(self, run_id: str, persona_json: str):
             persona_location = persona_data.get("location")
             persona_age = persona_data.get("age")
             persona_occupation = persona_data.get("occupation")
+            persona_description = persona_data.get("description")
 
             existing = await redis.get(f"result:s4:{run_id}:{persona_id}")
             if existing is not None:
                 vote = PersonaVote.model_validate_json(existing)
                 from app.pipeline.orchestrator import Orchestrator
                 await Orchestrator(redis).on_s4_complete(
-                    run_id, persona_id, vote.top_5_script_ids, persona_name=persona_name
+                    run_id, persona_id, vote.top_5_script_ids,
+                    persona_name=persona_name,
+                    persona_description=persona_description,
                 )
                 return
 
@@ -328,6 +331,7 @@ def s4_vote_task(self, run_id: str, persona_json: str):
                 "location": persona_location,
                 "age": persona_age,
                 "occupation": persona_occupation,
+                "description": persona_description,
             })
 
             async with _acquire_provider_slot(redis, config.reasoning_model):
@@ -335,7 +339,9 @@ def s4_vote_task(self, run_id: str, persona_json: str):
             await redis.set(f"result:s4:{run_id}:{persona_id}", vote.model_dump_json())
 
             await orchestrator.on_s4_complete(
-                run_id, persona_id, vote.top_5_script_ids, persona_name=persona_name
+                run_id, persona_id, vote.top_5_script_ids,
+                persona_name=persona_name,
+                persona_description=persona_description,
             )
         finally:
             await redis.aclose()

--- a/frontend/src/components/S4VoteMatrix.tsx
+++ b/frontend/src/components/S4VoteMatrix.tsx
@@ -34,6 +34,7 @@ interface VoterRow {
   location?: string;
   age?: number;
   occupation?: string;
+  description?: string;
   state: "pending" | "voting" | "voted";
   /** map from script_id → rank (0-indexed, 0 = voter's #1 pick) */
   ranks: Record<string, number>;
@@ -76,6 +77,7 @@ function deriveMatrix(
         location: (d.location as string) || undefined,
         age: (d.age as number) || undefined,
         occupation: (d.occupation as string) || undefined,
+        description: (d.description as string) || undefined,
         state: "voting",
         ranks: {},
       });
@@ -99,6 +101,8 @@ function deriveMatrix(
         location: existing?.location,
         age: existing?.age,
         occupation: existing?.occupation,
+        description:
+          (d.persona_description as string | undefined) ?? existing?.description,
         state: "voted",
         ranks,
       });
@@ -158,7 +162,8 @@ export default function S4VoteMatrix({ events, totalPersonas }: S4VoteMatrixProp
   const votingRows = rows.filter((r) => r.state === "voting").length;
 
   const CELL = 22;
-  const NAME_W = 180;
+  const ROW_H = 36;  // taller than CELL so bio line fits comfortably
+  const NAME_W = 260;
 
   return (
     <div className="space-y-3">
@@ -223,17 +228,22 @@ export default function S4VoteMatrix({ events, totalPersonas }: S4VoteMatrixProp
               row.occupation || null,
               country(row.location) || null,
             ].filter(Boolean);
+            const tooltipParts = [
+              row.displayName,
+              row.location,
+              row.description,
+            ].filter(Boolean);
             return (
-              <div key={row.personaId} className="flex">
-                {/* Name sidebar — two lines */}
+              <div key={row.personaId} className="flex items-center">
+                {/* Name sidebar — name, subtitle, bio preview */}
                 <div
-                  className="flex flex-col justify-center pr-2 truncate"
+                  className="flex flex-col justify-center pr-3 overflow-hidden"
                   style={{
                     width: NAME_W,
-                    height: CELL,
+                    height: ROW_H,
                     opacity: row.state === "pending" ? 0.35 : 1,
                   }}
-                  title={row.location ? `${row.displayName} — ${row.location}` : row.displayName}
+                  title={tooltipParts.join(" — ")}
                 >
                   <span
                     className="font-mono text-[11px] leading-none truncate"
@@ -249,6 +259,14 @@ export default function S4VoteMatrix({ events, totalPersonas }: S4VoteMatrixProp
                   {subtitleParts.length > 0 && (
                     <span className="font-ui text-[9px] leading-none text-[var(--color-text-muted)] truncate mt-0.5">
                       {subtitleParts.join(" · ")}
+                    </span>
+                  )}
+                  {row.description && (
+                    <span
+                      className="font-ui text-[9px] leading-tight text-[var(--color-text-muted)] truncate mt-0.5 italic"
+                      style={{ opacity: 0.75 }}
+                    >
+                      {row.description}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
Voters in the matrix currently show only name + age/occupation/country. The rich 2-3 sentence description from \`personas.json\` was never plumbed through to the SSE events, so the UI couldn't show it.

## Changes
- **Backend:** \`s4_task_started\` and \`vote_cast\` events now carry the persona description
- **Frontend:** third line under each voter name shows the bio (truncated, italic). Full bio in hover tooltip. Row height increased from 22px → 36px to fit.

## Test plan
- [x] 112 unit tests pass, lint clean
- [ ] Deploy — S4 voters should now show bios like "Luna treats TikTok as her choreography notebook..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)