### PR TITLE
docs: update lessons for current architecture

### DIFF
--- a/docs/lessons/02-the-deployed-architecture.md
+++ b/docs/lessons/02-the-deployed-architecture.md
@@ -4,7 +4,7 @@
 
 ## A note on honesty
 
-The original architecture doc (`design/architecture.md`) says the backend deploys to Railway and the frontend to Cloudflare Pages. In reality, the backend runs on AWS ECS Fargate with ElastiCache Redis, and the frontend is an S3 static website. The Gemini API is mentioned throughout the design docs and experiment reports — in reality, the production provider is Kimi (Moonshot AI), accessed through an OpenAI-compatible endpoint. The architecture doc hasn't been updated.
+The original architecture doc (`design/architecture.md`) says the backend deploys to Railway and the frontend to Cloudflare Pages. In reality, the backend runs on AWS ECS Fargate with ElastiCache Redis, and the frontend is an S3 static website. The Gemini API is mentioned throughout the design docs and experiment reports — in reality, the production provider is Kimi (Moonshot AI), accessed over Kimi's coding endpoint using the Anthropic Messages API. The architecture doc hasn't been updated.
 
 This is the single most common documentation failure in software: **design docs freeze at the point they were written.** Always verify against the code and the infrastructure. `git log`, `grep`, and `terraform plan` are more trustworthy than any markdown file.
 
@@ -42,8 +42,8 @@ This article describes the real system as of April 2026, verified against code a
                     └────────┬───────┘
                              │
                     ┌────────┴────────┐
-                    │    Kimi API     │  OpenAI-compatible LLM
-                    │ (Moonshot AI)   │  via OpenAI Python SDK
+                    │    Kimi API     │  Anthropic Messages API
+                    │ (Moonshot AI)   │  via anthropic Python SDK
                     └─────────────────┘
 
 
@@ -110,9 +110,9 @@ This article describes the real system as of April 2026, verified against code a
 **File:** `backend/app/providers/kimi.py`
 **File:** `backend/app/providers/registry.py`
 
-**How it connects:** Kimi exposes an OpenAI-compatible API. The `KimiProvider` class uses the official OpenAI Python SDK with a custom `base_url` and a `default_headers` override for User-Agent (Kimi requires this). This is a common pattern — many LLM providers ship OpenAI-compatible endpoints so existing client code works with a base URL swap.
+**How it connects:** Kimi's coding endpoint speaks the **Anthropic Messages API** at `/coding/v1/messages`. The `KimiProvider` uses the `AsyncAnthropic` client with `base_url="https://api.kimi.com/coding"` and a `default_headers` override for User-Agent (Kimi's endpoint whitelists approved coding agents — Claude Code, Kimi CLI, etc.). An earlier version of the endpoint spoke OpenAI's `chat/completions` schema; that surface went dead in early 2026 and we migrated to Anthropic's SDK. See [Article 15](15-kimi-and-openai-compatibility.md) for the migration story.
 
-**The migration story:** The system was originally built for Gemini. PR #95 ("chore: remove Gemini secret requirement, Kimi-only deployment") made the switch. Because the provider was behind a registry abstraction (`providers/registry.py`), the migration was a configuration change, not a code rewrite. The `GeminiProvider` class still exists in the codebase — it's just not wired up in production.
+**The migration stories:** Plural, now. First Gemini → Kimi (PR #95: "remove Gemini secret requirement"), driven by Gemini's intermittent 500s and rate-limit issues. Then OpenAI SDK → Anthropic SDK, driven by Kimi deprecating their OpenAI-compatible shim. Both migrations only touched `providers/kimi.py` because every stage calls through the `ReasoningProvider` Protocol. The `GeminiProvider` class still exists; it's just not wired up in production.
 
 ### Frontend (Astro + React on S3)
 

--- a/docs/lessons/05-sse-and-redis-streams.md
+++ b/docs/lessons/05-sse-and-redis-streams.md
@@ -157,14 +157,21 @@ The orchestrator publishes these events to the stream (via `XADD`):
 |-------|------|------|
 | `pipeline_started` | Run begins | `run_id`, `total_videos`, `total_personas`, `top_n` |
 | `stage_started` | Each stage begins | `stage` name, `total_items` |
-| `s1_progress` | Each video analyzed | `video_id`, `completed`, `total` |
+| `s1_task_started` | A worker picks up an S1 task (before LLM call) | `video_id`, `description` (snippet) |
+| `s1_progress` | Each video analyzed | `video_id`, `completed`, `total`, `hook_type`, `pacing`, `trigger_count` |
+| `s1_video_skipped` | One video un-analyzable after retries exhausted | `video_id`, `reason`, `completed`, `total` |
 | `s2_complete` | Aggregation done | `pattern_count` |
-| `s3_complete` | Generation done | `script_count` |
-| `vote_cast` | Each persona votes | `persona_id`, `top_5`, `completed`, `total` |
+| `s3_progress` | Each script generated (sequential) | `script_id`, `completed`, `total` |
+| `s3_complete` | Generation done | `script_count`, `script_ids` |
+| `s4_task_started` | A worker picks up a vote task | `persona_id`, `name`, `age`, `location`, `occupation`, `description` |
+| `vote_cast` | Each persona votes | `persona_id`, `persona_name`, `persona_description`, `top_5`, `completed`, `total` |
 | `s5_complete` | Ranking done | `top_ids`, `top_n` |
 | `s6_progress` | Each script personalized | `script_id`, `completed`, `total` |
 | `pipeline_completed` | Run finished | `run_id`, `result_count` |
 | `pipeline_error` | Run failed | `stage`, `error`, `recoverable` |
+| `pipeline_recovered` | Crash recovery replayed from S4 checkpoint | `run_id`, `s4_checkpoint`, `remaining_personas` |
+
+**The `*_task_started` pattern:** events fire the moment a worker picks up a task, *before* the LLM call. This is what drives the concurrency meters on the frontend — the S1 grid can show "8 cards pulsing" because it sees 8 `s1_task_started` events that haven't yet been followed by `s1_progress`. Without these events, the UI would jump cards straight from `pending` to `completed` and lose the "work in progress" state entirely.
 
 **Notice the pattern:** progress events for fan-out stages (S1, S4, S6) include `completed` and `total` counts. This lets the frontend show a progress bar: "Analyzing video 37 of 100" or "42 of 100 personas have voted." The frontend doesn't need to track state — each event carries enough context to render the current state.
 

--- a/docs/lessons/06-the-request-lifecycle.md
+++ b/docs/lessons/06-the-request-lifecycle.md
@@ -116,11 +116,13 @@ Each of the 2-4 Celery workers pulls `s1_analyze_task` messages from Redis db=1.
 done = await self._r.incr(f"run:{run_id}:s1:done")  # atomic increment
 ```
 
-This is the coordination mechanism. 100 workers might be completing S1 tasks concurrently. `INCR` is atomic in Redis — exactly one of them will see `done == 100` and trigger the transition to S2.
+This is the coordination mechanism. 100 workers might be completing S1 tasks concurrently. `INCR` is atomic in Redis — each caller gets a unique sequence number.
 
 The orchestrator publishes `s1_progress` events to the stream. The SSE manager picks them up. The browser shows: "Analyzed 1/100... 2/100... 42/100..."
 
-When `done >= config.num_videos`, the orchestrator calls `_transition_s2()`.
+**Completion threshold — 95%, not 100%.** Since a rate-limited task can retry for up to ~10 minutes (see [Article 16](16-rate-limiting.md)), waiting for every single task to finish would let one straggler gate the whole pipeline. The orchestrator's `_try_transition` helper fires when `done >= ceil(num_videos * 0.95)` — 95 of 100 for a full run. Late completers still `INCR` the counter; a SETNX guard on `run:{id}:s2:triggered` ensures the transition only fires once, even if multiple completions cross the threshold in the same millisecond. Skipped videos (from the [skip-and-continue path](09-worker-lifecycle-and-failure.md)) also count toward the threshold — one un-analyzable video doesn't block S2.
+
+For small runs (fewer than ~20 videos) the `ceil` rounds the threshold up to "all tasks," so the behavior matches the old all-or-nothing wait. The threshold only changes behavior at scale, which is exactly where stragglers bite.
 
 ## Phase 5: S2 — Reduce (aggregate patterns) (sub-second)
 

--- a/docs/lessons/09-worker-lifecycle-and-failure.md
+++ b/docs/lessons/09-worker-lifecycle-and-failure.md
@@ -33,9 +33,14 @@ The task function throws an error. Maybe Kimi returned unparseable JSON, or the 
 3. The task IS acknowledged (removed from the queue) — even with `acks_late=True`
 4. The exception is logged
 
-**In Flair2:** the task's error handler catches `ProviderError` and `StageError` and calls `orchestrator.on_failure()`, which marks the entire run as failed and publishes a `pipeline_error` event to the SSE stream. The user sees "Pipeline failed at S1: rate limit exceeded" in real time.
+**In Flair2:** the task's error handler catches `ProviderError` and `StageError`. What happens next depends on which stage failed:
 
-**Design choice:** Flair2 does NOT retry on exception by default. An LLM error that produced unparseable output is likely to produce unparseable output again. Instead, the run fails and the user can start a new one. This is a deliberate choice — automatic retry is appropriate for transient errors (network blip), not for semantic errors (bad LLM output).
+- **S1 (fan-out over videos):** the task calls `orchestrator.on_s1_skipped()` — mark this ONE video as un-analyzable, increment the same counter as a successful analysis, publish `s1_video_skipped` to the SSE stream. The other 99 videos keep going. This is the **skip-and-continue** pattern: one bad input should never kill the whole run.
+- **S2, S3, S5, S6:** these are single-task (S2/S3/S5) or small fan-outs (S6) where there's no useful notion of "continue without this one." The task calls `orchestrator.on_failure()`, which marks the run as failed and publishes `pipeline_error`.
+
+The difference is surface area. With 100 S1 tasks, the probability of at least one hitting a weird LLM response approaches 1 as N grows. Killing the run every time would make the system unusable at scale. With 1 S3 task, there's nothing to fall back to — if S3 fails, there are no scripts to vote on.
+
+**Design choice:** Flair2 retries transient errors at the provider level (3 attempts with backoff, 4 more for rate limits — see [Article 16](16-rate-limiting.md)) and the Celery task level (5 attempts with jitter) before giving up. Only after all retries exhaust does the stage decide whether to skip (S1) or fail the run (everything else).
 
 If you wanted automatic retry, Celery supports it:
 

--- a/docs/lessons/14-the-provider-abstraction.md
+++ b/docs/lessons/14-the-provider-abstraction.md
@@ -151,17 +151,17 @@ class KimiProvider:
 
     def _get_client(self):
         if self._client is None:
-            from openai import OpenAI
-            self._client = OpenAI(
+            from anthropic import AsyncAnthropic
+            self._client = AsyncAnthropic(
                 api_key=self._api_key,
-                base_url=KIMI_BASE_URL,
+                base_url=KIMI_BASE_URL,                        # "https://api.kimi.com/coding"
                 default_headers={"User-Agent": KIMI_USER_AGENT},
                 timeout=120.0,
             )
         return self._client
 ```
 
-Kimi uses the OpenAI Python SDK with a custom `base_url`. This is the **OpenAI-compatible API pattern** — covered in detail in [Article 15](15-kimi-and-openai-compatibility.md).
+Kimi speaks the **Anthropic Messages API** on its coding endpoint. We use the `AsyncAnthropic` client with a custom `base_url`. (An earlier version of Kimi spoke OpenAI's chat/completions schema instead — that surface went dead and the client had to migrate. [Article 15](15-kimi-and-openai-compatibility.md) covers the migration history and why the abstraction let us do it with a ~30-line change.)
 
 ### GeminiProvider (`providers/gemini.py`)
 

--- a/docs/lessons/15-kimi-and-openai-compatibility.md
+++ b/docs/lessons/15-kimi-and-openai-compatibility.md
@@ -1,40 +1,42 @@
-# 15. Kimi and the OpenAI Compatibility Layer
+# 15. Kimi and the Anthropic Messages Migration
 
-> Most new LLM providers ship an OpenAI-compatible API endpoint. Understanding why this pattern exists and how it works gives you a practical skill: swap LLM providers without rewriting client code.
+> Industry-standard APIs come and go. Between the hackathon prototype and today, Flair2 migrated its LLM client twice — first to OpenAI's chat/completions schema, then to Anthropic's Messages API. This article explains why both moves happened, what the current wiring looks like, and the transferable lesson about coding against an interface.
 
-## The industry pattern
+## Two migrations in one project
 
-OpenAI's Chat Completions API has become a de facto standard. The key endpoint:
+When the Kimi provider was first added, Kimi's coding endpoint exposed an OpenAI-compatible `chat/completions` route. That made integration cheap: use the OpenAI Python SDK, swap `base_url`, done. Many Chinese LLM providers did this to attract developers already using OpenAI's SDK.
 
+Then Kimi's endpoint quietly changed. The OpenAI-shaped route started returning a misleading error — `"only 0.6 is allowed for this model"` — for every request regardless of temperature. The real surface moved to an Anthropic Messages API shape at `/coding/v1/messages`. So we migrated again, this time to the Anthropic Python SDK.
+
+This sequence is now permanently documented in the provider file's docstring:
+
+```python
+"""Kimi (Moonshot AI) reasoning provider via the Anthropic Messages API.
+
+Kimi's coding endpoint migrated to an Anthropic-compatible schema
+(see /coding/v1/messages). The legacy OpenAI /chat/completions shim
+now returns a misleading "only 0.6 is allowed for this model" error
+for every request, regardless of temperature — a dead surface.
+"""
 ```
-POST /v1/chat/completions
-{
-  "model": "gpt-4",
-  "messages": [{"role": "user", "content": "Hello"}],
-  "max_tokens": 1000
-}
-```
 
-Many LLM providers — including Kimi (Moonshot AI), Together AI, Groq, Anyscale, Fireworks, and dozens of others — implement this exact API shape at their own endpoint. You can use the official OpenAI Python SDK, point it at a different `base_url`, and it works.
+**The transferable lesson:** LLM provider APIs are not stable contracts. Public pricing pages and "OpenAI compatible" claims can change month to month. Design your provider abstraction so migrations are one file's worth of work.
 
-**Why providers do this:** the OpenAI SDK is the most widely used LLM client library. By matching its API, providers get instant compatibility with every tool, framework, and tutorial that uses the OpenAI SDK. It's free adoption.
-
-**Why this matters for you:** if you build your LLM integration around the OpenAI SDK, switching providers is a configuration change (new base URL + API key), not a code rewrite.
-
-## How Kimi uses it
+## The current wiring
 
 **File:** `backend/app/providers/kimi.py`
 
 ```python
-KIMI_BASE_URL = "https://api.kimi.com/coding/v1"
-KIMI_MODEL = "kimi-for-coding/k2p5"
+KIMI_BASE_URL = "https://api.kimi.com/coding"  # no /v1 — SDK appends /v1/messages
+KIMI_MODEL = "kimi-for-coding"                 # or "kimi-k2.5"
 KIMI_USER_AGENT = "claude-code/0.1.0"
 
 class KimiProvider:
     def _get_client(self):
         if self._client is None:
-            from openai import OpenAI
-            self._client = OpenAI(
+            from anthropic import AsyncAnthropic
+
+            self._client = AsyncAnthropic(
                 api_key=self._api_key,
                 base_url=KIMI_BASE_URL,
                 default_headers={"User-Agent": KIMI_USER_AGENT},
@@ -43,160 +45,76 @@ class KimiProvider:
         return self._client
 ```
 
-Three things are swapped from the default OpenAI configuration:
+Three things changed from the OpenAI era:
 
-### 1. `base_url`
+### 1. Different SDK
 
-Instead of `https://api.openai.com/v1`, requests go to `https://api.kimi.com/coding/v1`. The SDK appends the endpoint path (`/chat/completions`) to this base URL. All request/response formatting stays the same.
+`AsyncAnthropic` instead of `OpenAI`. Same pattern (base_url + default_headers), different package. The rest of the provider code — retry logic, rate-limit handling, JSON parsing — didn't change because it doesn't depend on the SDK.
 
-### 2. `api_key`
+### 2. Different endpoint shape
 
-Kimi has its own API keys, separate from OpenAI. The key is passed to the same `api_key` parameter. The SDK includes it as a `Bearer` token in the `Authorization` header, which is the standard OAuth2 pattern.
+`base_url` stops at `/coding`, not `/coding/v1`, because the Anthropic SDK appends `/v1/messages` automatically. Getting this wrong silently breaks everything with a 404.
 
-### 3. `default_headers`
+### 3. Different request/response shape
 
-```python
-default_headers={"User-Agent": KIMI_USER_AGENT}
-```
+Requests use `client.messages.create(...)` with `messages=[...]` and `max_tokens` (required in Anthropic's API, optional in OpenAI's). Responses are `Message` objects with a `content` list of content blocks — each block has a `type` ("text", "tool_use", etc.) and a `text` attribute for text blocks.
 
-This is the interesting one. Kimi requires (or at least expects) a specific User-Agent header. The OpenAI SDK's default User-Agent is something like `openai-python/1.x.x`. Kimi might reject or rate-limit requests with that UA.
-
-The `default_headers` parameter on the OpenAI client adds these headers to every request. This is the workaround for provider-specific quirks that the standard API shape doesn't account for.
-
-**PR history:** this was fixed in PR #67 ("fix: use OpenAI default_headers for Kimi User-Agent"). Before that, the UA was being set some other way that didn't work reliably.
-
-## The API call
+Flair2 only cares about text, so it flattens the content blocks:
 
 ```python
-response = await asyncio.to_thread(
-    client.chat.completions.create,
-    model=self._model,
-    messages=[{"role": "user", "content": prompt}],
-    max_tokens=32768,
-)
-text = response.choices[0].message.content
+def _extract_text(response) -> str:
+    parts: list[str] = []
+    for block in response.content:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    return "".join(parts)
 ```
 
-**`asyncio.to_thread`:** the OpenAI Python SDK's synchronous client (`OpenAI`, not `AsyncOpenAI`) is used here, wrapped in `asyncio.to_thread` to avoid blocking the event loop. This runs the synchronous HTTP call in a thread pool.
+## The User-Agent whitelist (still required)
 
-**Why not `AsyncOpenAI`?** It would work too. The choice of sync-in-thread vs async is a pragmatic one — both work, sync is simpler to debug (stack traces are clearer), and the threading overhead is negligible for 2-5 second LLM calls.
+Kimi's coding endpoint is gated on User-Agent. Only approved coding agents (Kimi CLI, Claude Code, Roo Code, etc.) can use it. Unrecognized clients get 403: *"Kimi For Coding is currently only available for Coding Agents."*
 
-**Response parsing:** `response.choices[0].message.content` — the standard OpenAI response structure. Kimi returns responses in the same format: a list of `choices`, each with a `message` containing `role` and `content`.
+The `default_headers={"User-Agent": "claude-code/0.1.0"}` line is the whitelist workaround. Same fragility it had during the OpenAI era — if Kimi tightens validation, the spoof breaks. Nothing about migrating to Anthropic's SDK fixed this; it's an endpoint policy, not an SDK behavior.
 
-**Token usage:**
-```python
-if response.usage:
-    self.last_usage = {
-        "input_tokens": response.usage.prompt_tokens,
-        "output_tokens": response.usage.completion_tokens,
-    }
-```
+## The registry abstraction paid off twice
 
-The `usage` field is part of the OpenAI response spec. Kimi populates it. This lets Flair2 track token consumption across calls — useful for cost monitoring.
+Because every stage calls `provider.generate_text(...)` through the `ReasoningProvider` Protocol ([Article 14](14-the-provider-abstraction.md)), **two SDK migrations didn't touch any stage code.** S1, S3, S4, S6 have no idea which SDK sits behind the provider. The only files that changed across migrations:
 
-## Comparing with GeminiProvider
+- `providers/kimi.py` — the SDK wrapper
+- `pyproject.toml` — the dependency (anthropic instead of openai)
+- Tests that specifically asserted OpenAI SDK behavior
 
-Gemini does NOT use the OpenAI-compatible pattern. It has its own SDK:
+Every other part of the codebase — orchestrator, workers, stages, frontend — was unaffected. This is the dividend of programming to an interface. When the interface is stable and the implementation changes, only the implementation file changes.
 
-```python
-# Gemini — different SDK, different API:
-from google import genai
-client = genai.Client(api_key=self._api_key)
-response = await asyncio.to_thread(
-    client.models.generate_content,
-    model=self._model,
-    contents=prompt,
-)
-text = response.text
-```
+## Model IDs
 
-Different import, different client class, different method name, different response structure. This is why the `ReasoningProvider` abstraction exists — it hides these differences behind a common `generate_text()` method.
+The coding endpoint accepts multiple model aliases:
 
-If Gemini offered an OpenAI-compatible endpoint (some Google models do through Vertex AI), both providers could use the same OpenAI SDK with different base URLs. The abstraction would still be useful (different rate limit detection, different error shapes), but the client code would be nearly identical.
+| Model ID | What it is |
+|----------|-----------|
+| `kimi-for-coding` | Default; routes to the current coding-optimized model |
+| `kimi-for-coding/k2p5` | Coding-specific variant of K2.5 |
+| `kimi-k2.5` | General-purpose K2.5 (accepted on coding endpoint since Kimi unified their credit pool in April 2026) |
 
-## The `extract_json` utility
+The code uses `kimi-for-coding` as the default. All three currently work because Kimi unified billing across Kimi Code, Kimi Chat, Agent, and PPT — the coding endpoint will accept general models too.
 
-**File:** `backend/app/providers/utils.py`
+## Retry & rate-limit behavior
 
-Both providers use a shared utility to extract JSON from LLM responses. LLMs often wrap JSON in markdown code fences:
-
-````
-Here is the analysis:
-
-```json
-{"hook_type": "question", "pacing": "fast", ...}
-```
-
-I hope this helps!
-````
-
-`extract_json()` strips the wrapping and returns just the JSON string. This is a shared concern — all LLM providers have this problem, regardless of which API they use.
-
-## Retry and error handling
-
-Both KimiProvider and GeminiProvider implement the same retry pattern:
-
-```python
-BACKOFF_SECS = [1, 2, 4]
-MAX_RETRIES = 3
-
-for attempt in range(MAX_RETRIES):
-    try:
-        response = ...  # API call
-        # parse response...
-        return result
-    except Exception as e:
-        if is_rate_limit(e):
-            await asyncio.sleep(BACKOFF_SECS[attempt])
-            continue
-        raise ProviderError(str(e), provider=self.name)
-```
-
-**Exponential backoff:** 1s, 2s, 4s. Each retry waits longer. This is the standard pattern for handling rate limits — give the provider time to reset its counter.
-
-**Rate limit detection is provider-specific:**
-- Kimi: `"429" in str(e) or "rate" in str(e).lower()`
-- Gemini: `"429" in str(e) or "RESOURCE_EXHAUSTED" in str(e)`
-
-The error string matching is fragile (it depends on the exact error message format), but it works for known providers. A more robust approach would check `e.status_code == 429` directly.
-
-## Adding a new provider
-
-To add a hypothetical Claude provider:
-
-1. Create `backend/app/providers/claude.py`:
-```python
-class ClaudeProvider:
-    name = "claude"
-    async def generate_text(self, prompt, schema=None):
-        # Use Anthropic SDK
-        ...
-```
-
-2. Register it in `backend/app/providers/registry.py`:
-```python
-from app.providers.claude import ClaudeProvider
-_reasoning_providers["claude"] = ClaudeProvider
-```
-
-3. Add `claude_api_key` and `claude_rpm` to `backend/app/config.py`
-
-4. Add `"claude": settings.claude_api_key` to `_get_provider`'s `key_map` in `tasks.py`
-
-That's it. No stage functions change. No orchestrator changes. No SSE changes. No tests change (except adding provider-specific tests).
+Provider-level retries are covered in [Article 16](16-rate-limiting.md). Key detail: the provider separates retry budgets by error class. Transient parse/schema errors get a short 3-attempt budget (1s/2s/4s). Concurrency rate limits (429s) get their own patient 4-attempt budget (8s/20s/45s/90s with ±30% jitter). The two don't share a budget, so a rate-limited task doesn't exhaust its retries on fast backoffs before the limit clears.
 
 ## What you should take from this
 
-1. **OpenAI-compatible APIs are the industry standard.** If you're integrating with an LLM provider, check if they have an OpenAI-compatible endpoint. If they do, you can reuse the OpenAI SDK.
+1. **"X-compatible API" claims are promises with an expiration date.** OpenAI compatibility worked for Kimi until it didn't. Don't hardcode to the shape; hide it behind an interface.
 
-2. **`base_url` + `api_key` + `default_headers` are the three knobs.** That's all you need to point the OpenAI SDK at a different provider.
+2. **`base_url` + `default_headers` is a pattern, not an SDK feature.** Both OpenAI's and Anthropic's Python SDKs expose it. If you're using one, you can use the other. The migration was ~30 lines.
 
-3. **`asyncio.to_thread` is the bridge between sync and async.** When you have a synchronous SDK and an async application, wrap the call in `to_thread` to avoid blocking the event loop.
+3. **Endpoint policies (UA whitelist) survive SDK migrations.** When you switch clients, carry forward the policy workarounds or you'll be debugging a 403 for an hour.
 
-4. **Shared utilities (`extract_json`) reduce code duplication across providers.** Provider-specific code handles auth and error detection; shared code handles response parsing.
+4. **Provider code is churn-heavy; stage code shouldn't be.** Two migrations, zero changes to S1-S6. The interface pays for itself in rewrite-avoidance.
 
-5. **Every provider will need custom error detection.** HTTP 429 is standard, but the error message format varies. Encapsulate provider-specific error handling inside the provider class, not in the caller.
+5. **Document the history in the docstring.** The "legacy OpenAI shim returns a misleading error" comment in `kimi.py` is load-bearing. Six months from now, somebody will try the OpenAI route again and be confused — the comment tells them why not to.
 
 ---
 
-***Next: [Rate Limiting a Shared Upstream](16-rate-limiting.md) — the token bucket algorithm, centralized vs distributed rate limiting, and a documented race condition.***
+***Next: [Rate Limiting a Shared Upstream](16-rate-limiting.md) — the retry-budget-per-error-class pattern that keeps Flair2 alive under Kimi's concurrency throttling.***

--- a/docs/lessons/16-rate-limiting.md
+++ b/docs/lessons/16-rate-limiting.md
@@ -2,6 +2,8 @@
 
 > When multiple workers share one API key with a per-minute rate limit, you need centralized coordination. This article teaches the token bucket algorithm, its Redis implementation, and a documented race condition you should know about.
 
+> **Note (April 2026):** production has since moved from the token-bucket to a **Redis semaphore** because Kimi's real constraint turned out to be concurrent in-flight requests (≤30), not requests per minute. The token bucket lives on in the M5-1 backpressure experiment. Both mechanisms and the migration rationale are covered together below.
+
 ## The problem
 
 Kimi (and most LLM providers) enforce a per-minute rate limit — say, 60 requests per minute per API key. Flair2 has multiple workers, all using the same API key. If each worker independently tracks "how many calls have I made this minute," the total would exceed the limit because they can't see each other's counts.
@@ -182,6 +184,56 @@ The backpressure experiment (in `tests/experiments/test_backpressure.py`) tested
 Flair2 uses **fixed window** (counter + TTL), which has a known edge case: at the boundary between two windows, you could make `max_tokens` calls in the last second of window 1 and `max_tokens` calls in the first second of window 2 — double the intended rate in a 2-second burst. **Sliding window** fixes this by counting calls in a rolling time period, but it's more complex to implement in Redis.
 
 For Flair2's LLM calls (which take 2-5 seconds each), the boundary burst is impossible in practice — you can't make 60 calls in one second. The fixed window approximation is fine.
+
+## Production swap: semaphore replaces token bucket
+
+As Flair2 ran against real Kimi traffic, a pattern emerged: most 429s came not from exceeding a per-minute count but from exceeding **concurrent in-flight requests** (Kimi Code's cap is ~30). Rate/minute wasn't the right mental model.
+
+The fix, in `backend/app/infra/rate_limiter.py`, is a `RedisSemaphore` — a classic counting semaphore backed by an atomic Redis counter. Before each LLM call, the worker acquires a slot; after the call (or on exception), it releases. The semaphore size is set from `settings.kimi_max_concurrency = 29` (one headroom slot under Kimi's ceiling).
+
+```python
+@asynccontextmanager
+async def _acquire_provider_slot(redis, provider_name):
+    if not settings.enable_rate_limiter:
+        yield; return
+    max_slots = getattr(settings, f"{provider_name}_max_concurrency", None)
+    if not max_slots:
+        yield; return
+    sem = RedisSemaphore(redis, provider_name, max_slots=max_slots)
+    await sem.acquire()
+    try:
+        yield
+    finally:
+        await sem.release()
+```
+
+Each S1/S3/S4/S6 task wraps its LLM call in this context manager. The semaphore exposes actual concurrency, not a per-minute rate — which is what Kimi's endpoint actually cares about.
+
+**Why both still exist:** the token bucket is kept around because M5-1 (backpressure experiment) measures its fairness properties across K concurrent users. Production traffic goes through the semaphore. Two primitives, two purposes.
+
+## Retry budget per error class
+
+A second rate-limit improvement: when a 429 does get through (transient spikes happen), the provider retries it — but on a much longer schedule than regular errors.
+
+In `providers/kimi.py`:
+
+```python
+# Short backoff for transient parse/schema errors
+BACKOFF_SECS = [1, 2, 4]
+MAX_RETRIES = 3
+
+# Long backoff for 429s — Kimi's "too many concurrent" clears in 10-30s,
+# and jitter is critical when 100 tasks all hit the limit together.
+RATE_LIMIT_BACKOFF = [8, 20, 45, 90]
+RATE_LIMIT_JITTER_FRAC = 0.3
+RATE_LIMIT_MAX_RETRIES = len(RATE_LIMIT_BACKOFF)
+```
+
+Parse/schema errors and rate-limit errors have **separate retry budgets**. A task hitting repeated 429s doesn't burn its 3-attempt budget in 7 seconds — it gets 4 patient attempts totaling ~165 seconds plus jitter. If it still fails, `RateLimitError` is raised with `retry_after` set, and the Celery task wrapper uses that as its own retry countdown (with another ±25% jitter layer on top).
+
+**Total patience for a persistent 429:** ~165s at the provider, then up to 5 Celery retries at ~90s each. Roughly 10 minutes before giving up — enough time for almost any real concurrency throttling to clear.
+
+**The pattern:** don't mix fast and slow retries in the same budget. Transient noise deserves aggressive quick retries. Upstream throttling deserves patience. One budget can't satisfy both.
 
 ## What you should take from this
 


### PR DESCRIPTION
## Summary
Bring the 28-article teaching series in sync with the codebase. Nothing structural changed — this is a reality-check pass.

## Articles touched
- **#15** (Kimi and OpenAI Compatibility) — full rewrite. OpenAI-compatible route is dead; Kimi now speaks Anthropic Messages API. Article now documents the migration history + transferable lesson about interface stability.
- **#14** (Provider Abstraction) — KimiProvider code snippet uses AsyncAnthropic.
- **#2** (Deployed Architecture) — Anthropic SDK references, corrected base_url.
- **#16** (Rate Limiting) — added semaphore section (production now) and retry-budget-per-error-class section.
- **#6** (Request Lifecycle) — S1→S2 transitions at 95% (ceil), not 100%.
- **#5** (SSE and Redis Streams) — event table expanded with s1_task_started, s1_video_skipped, s3_progress, s4_task_started, pipeline_recovered.
- **#9** (Worker Lifecycle) — skip-and-continue pattern for S1 vs fail-the-run for other stages.

## Not changed
Articles 1, 3, 4, 7, 8, 10-13, 17-28 — still accurate. Verified the two that were flagged as stale but weren't (21: CPU targets unchanged, 25: no transition claims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)