### PR TITLE
feat: regenerate personas as real viewers

### DIFF
--- a/data/personas.json
+++ b/data/personas.json
@@ -1,0 +1,716 @@
+[
+  {
+    "persona_id": "persona_0",
+    "name": "Jieun",
+    "age": 20,
+    "location": "Busan, South Korea",
+    "occupation": "Chemistry student",
+    "interests": [
+      "K-drama clips",
+      "study motivation",
+      "cute animal videos",
+      "mukbang"
+    ],
+    "scroll_context": "Between morning lectures on campus benches, phone propped on her bag, volume low to avoid judgment",
+    "attention_style": "Stops for relatable exam stress or unexpected plot twists; swipes away from slow voiceovers or English without Korean subtitles",
+    "description": "Jieun lives in a goshiwon near her university and survives on convenience store triangle kimbap. She scrolls to dissociate from organic chemistry flashcards. Her algorithm is half study-with-me videos she never finishes and half chaotic food compilations. She comments rarely but sends everything to her group chat.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_1",
+    "name": "Marcus",
+    "age": 34,
+    "location": "Manchester, UK",
+    "occupation": "NHS psychiatric nurse",
+    "interests": [
+      "true crime summaries",
+      "dark humor",
+      "football highlights",
+      "budget cooking"
+    ],
+    "scroll_context": "3am on an empty ward, sitting in the nurses' station with one ear for patient call bells",
+    "attention_style": "Stops for quick, grimly funny takes on terrible situations; swipes away from loud jump scares or anything requiring sound in the quiet ward",
+    "description": "Marcus has worked night shifts long enough that his body no longer knows what sunlight is. He scrolls to stay awake, not to be entertained. Videos hit different at 3:47am when the ward smells of industrial cleaner and someone is always sleeping two doors down. He needs content that acknowledges life is absurd without demanding emotional labor.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_2",
+    "name": "Rosa",
+    "age": 41,
+    "location": "Phoenix, Arizona, USA",
+    "occupation": "Uber and Lyft driver",
+    "interests": [
+      "true crime",
+      "parenting fails",
+      "celebrity gossip",
+      "easy dinner ideas"
+    ],
+    "scroll_context": "Parked in airport queue lots or outside bars at 1am, phone mounted on dash, waiting for the next ping",
+    "attention_style": "Stops for drama she can follow without sound, or one-pot meals; swipes away from vertical videos filmed while driving or anything preachy about hustle culture",
+    "description": "Rosa drives 50 hours a week and knows every public bathroom in Maricopa County. Her car is her office, bedroom, and dining room. She scrolls in stolen minutes between rides, volume off, reading captions. She has no patience for people who film themselves crying—she has cried in this car and never made it content.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_3",
+    "name": "Amara",
+    "age": 28,
+    "location": "Lagos, Nigeria",
+    "occupation": "Customer service representative",
+    "interests": [
+      "Nollywood clips",
+      "relationship advice",
+      "wedding transformations",
+      "small business tips"
+    ],
+    "scroll_context": "Lunch break in her office's shared cafeteria, 45 minutes with her phone flat on the plastic table",
+    "attention_style": "Stops for family drama or practical money-saving hacks; swipes away from American accents explaining her own culture back to her or videos that waste 10 seconds before starting",
+    "description": "Amara shares a desk with two other reps and answers complaints about missing deliveries eight hours daily. Her break is sacred. She scrolls to remember there are lives outside this building with its flickering fluorescent lights. She saves videos about side hustles she will start next month, has done for three years.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_4",
+    "name": "Hiroshi",
+    "age": 63,
+    "location": "Osaka, Japan",
+    "occupation": "Retired postal worker",
+    "interests": [
+      "gardening tricks",
+      "grandchildren's content",
+      " Showa-era nostalgia",
+      "easy exercise"
+    ],
+    "scroll_context": "Evenings alone in his apartment, his granddaughter's old phone propped on the kotatsu, reading glasses on",
+    "attention_style": "Stops for faces his age doing anything competently or grandchildren showing him new things; swipes away from fast cuts, tiny text, or slang he cannot parse",
+    "description": "Hiroshi's granddaughter loaded the app and showed him how to scroll. That was two years ago. Now he sends her videos daily—mostly ones he does not fully understand but thinks she might like. He watches slowly, often replaying, sometimes falling asleep with the phone still glowing. The algorithm has learned his patience.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_5",
+    "name": "Fatima",
+    "age": 16,
+    "location": "Casablanca, Morocco",
+    "occupation": "High school student",
+    "interests": [
+      "makeup tutorials",
+      "study aesthetics",
+      "K-pop edits",
+      "relatable school moments"
+    ],
+    "scroll_context": "Back corner of history class, phone below desk level, one eye on the teacher's chalkboard movements",
+    "attention_style": "Stops for perfectly organized notes or dramatic teacher stories; swipes away from anything with her school's actual uniform visible or videos longer than her remaining class minutes",
+    "description": "Fatima's school bans phones but everyone has one. She has perfected the art of laughing silently, of the sudden straight-face when the teacher turns. Her scroll is furtive, adrenalized, better than the content itself sometimes. She watches at 2x speed by default now, her attention permanently fractured between two worlds.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_6",
+    "name": "Dmitri",
+    "age": 52,
+    "location": "Novosibirsk, Russia",
+    "occupation": "Long-haul truck driver",
+    "interests": [
+      "road life vlogs",
+      "mechanical repairs",
+      "Soviet songs remixed",
+      "absurdist humor"
+    ],
+    "scroll_context": "Parked at highway rest stops across Siberia, cab heater running, cooking dinner on his portable stove while scrolling",
+    "attention_style": "Stops for other drivers documenting the same empty roads he knows; swipes away from city people complaining about traffic or fake-dangerous driving stunts",
+    "description": "Dmitri's cab is 3 meters by 2 and he lives in it two weeks at a time. The scroll connects him to other solitary men in metal boxes moving goods no one thinks about. He watches videos about his exact engine model, about meals cooked in exactly his conditions. He comments rarely but meaningfully, usually correcting someone's route advice.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_7",
+    "name": "Priya",
+    "age": 31,
+    "location": "Mumbai, India",
+    "occupation": "Stay-at-home mother",
+    "interests": [
+      "baby sleep tips",
+      "quick recipes",
+      "mom humor",
+      "home organization"
+    ],
+    "scroll_context": "Nursing her 8-month-old at 4am, phone dimmed to minimum, scrolling one-handed in the dark nursery",
+    "attention_style": "Stops for validation that exhaustion is normal or hacks that require no energy; swipes away from perfect mothers with perfect homes or anything judgmental about screen time",
+    "description": "Priya has not slept more than three consecutive hours in eight months. Her body is not her own, her time is not her own, but this scroll is hers. She watches other mothers at 4am across the world, this invisible sisterhood of the sleepless. She saves videos she will never have energy to try. The scrolling itself is the point.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_8",
+    "name": "Kwame",
+    "age": 24,
+    "location": "Accra, Ghana",
+    "occupation": "Construction site laborer",
+    "interests": [
+      "football skills",
+      "motivational speeches",
+      "music videos",
+      "comedy skits"
+    ],
+    "scroll_context": "Friday evenings on shared mattresses in his workers' hostel, phone charging from the one working outlet, weekend beginning",
+    "attention_style": "Stops for high energy and recognizable faces from home; swipes away from slow-building stories or content that assumes indoor leisure time",
+    "description": "Kwame pours concrete six days weekly and sends half his pay home. Friday is for recovery and reconnection—he scrolls to feel part of something larger than this temporary site, these temporary rooms. He watches loudly, shares with roommates, argues about football transfers. The scroll is social, communal, earned through six days of physical exhaustion.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_9",
+    "name": "Elena",
+    "age": 45,
+    "location": "Bucharest, Romania",
+    "occupation": "Factory quality control inspector",
+    "interests": [
+      "true crime psychology",
+      "home renovation",
+      "medical mysteries",
+      "rescue animals"
+    ],
+    "scroll_context": "Two 15-minute breaks daily in the factory's designated smoking area, standing because all seats are taken",
+    "attention_style": "Stops for complete narrative arcs she can finish in one break; swipes away from multipart series or anything requiring previous context",
+    "description": "Elena checks circuit boards for eight hours, her eyes tired from magnification lenses. Her breaks are precisely timed, her scroll deliberately chosen. She needs content that respects her time constraint, that offers closure. She has developed strong opinions about which true crime narrators waste her minutes with unnecessary biography. She never subscribes—too permanent—but remembers names to search.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_10",
+    "name": "Chen",
+    "age": 38,
+    "location": "Shenzhen, China",
+    "occupation": "Warehouse night shift supervisor",
+    "interests": [
+      "cooking tutorials",
+      "factory worker life",
+      "drama recaps",
+      "lottery unboxing"
+    ],
+    "scroll_context": "3am in the break room, fluorescent lights, instant noodles cooling, eight hours still remaining",
+    "attention_style": "Stops for other night workers documenting this invisible schedule; swipes away from daytime reality or content that assumes natural light is normal",
+    "description": "Chen manages inventory while others sleep and has not seen his family awake on a weekday in years. He scrolls to confirm others live this way too, that the world has not forgotten the night. He watches cooking videos for food he will make on his one day off, lives through others' daylight. The algorithm shows him more darkness than he would choose.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_11",
+    "name": "Sofia",
+    "age": 19,
+    "location": "São Paulo, Brazil",
+    "occupation": "Hairdressing apprentice",
+    "interests": [
+      "hair transformations",
+      "client horror stories",
+      "fashion hauls",
+      "ASMR"
+    ],
+    "scroll_context": "Between clients in the salon's back area, bleach-stained apron still on, waiting for color to process or next appointment to arrive",
+    "attention_style": "Stops for satisfying before/afters or drama she can share with colleagues; swipes away from techniques she already knows or influencers who have clearly never worked salon hours",
+    "description": "Sofia sweeps hair for eight hours hoping to be trusted with scissors. Her scroll is professional development disguised as entertainment—she watches for trends, for warnings, for the future she is working toward. She sends videos to her mother with captions like 'when I have my own chair.' The dream is specific: not fame, just competence, respect, her name on a station.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_12",
+    "name": "Yuki",
+    "age": 26,
+    "location": "Sapporo, Japan",
+    "occupation": "Graduate student in glaciology",
+    "interests": [
+      "fieldwork fails",
+      "climate anxiety humor",
+      "productivity systems",
+      "rare animal footage"
+    ],
+    "scroll_context": "Procrastinating in her lab's empty conference room, thesis document minimized, guilt already present",
+    "attention_style": "Stops for academic misery she can relate to or pure escapism with no educational value; swipes away from 'study with me' videos that remind her of her own failure to study",
+    "description": "Yuki has been 'writing' her thesis for fourteen months. The scroll is her shame and her comfort, proof that others also avoid their work, also panic, also survive. She watches field scientists in worse conditions than hers, feels briefly better, then worse. She has complicated theories about which procrastination content is healthy versus harmful but applies none of them.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_13",
+    "name": "Aisha",
+    "age": 56,
+    "location": "Minneapolis, USA",
+    "occupation": "Disabled former teacher, pensioner",
+    "interests": [
+      "disability advocacy",
+      "gentle crafts",
+      "nature documentaries",
+      "comfort cooking"
+    ],
+    "scroll_context": "Afternoons in her apartment, mobility scooter positioned by the window, world arriving through screen",
+    "attention_style": "Stops for genuine disability representation or slow, detailed processes she can follow; swipes away from inspiration porn or 'overcoming' narratives that erase systemic barriers",
+    "description": "Aisha's chronic condition removed her from classrooms but not from curiosity. She scrolls because her body no longer carries her to experience, so experience must come to her. She is patient with content, watches long-form, reads comments like social texture. She has time others waste and wastes none of it—every scroll is chosen, every pause considered. The feed is not escape. It is her geography now.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_14",
+    "name": "Priya",
+    "age": 26,
+    "location": "Ahmedabad, India",
+    "occupation": "ICU nurse",
+    "interests": [
+      "true crime podcasts",
+      "budget skincare",
+      "Bollywood gossip",
+      "easy recipes"
+    ],
+    "scroll_context": "3am to 5am during night shifts when patients are stable and the ward is quiet except for monitors",
+    "attention_style": "Stops for emotional medical stories, relatable nurse humor, or satisfying ASMR cleaning; swipes away from jump scares, loud sudden noises, or anything that reminds her of codes she just ran",
+    "description": "Priya works 12-hour night shifts at a public hospital and uses short videos to stay awake during the dead hours. She keeps one earbud in to hear call bells, so she favors captions and visual storytelling. She'll watch a 3-minute storytime about a patient's weird symptoms but skips anything with screaming or fake medical drama.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_15",
+    "name": "Darnell",
+    "age": 19,
+    "location": "Houston, USA",
+    "occupation": "Warehouse picker",
+    "interests": [
+      "NBA highlights",
+      "streetwear unboxings",
+      "hood cooking videos",
+      "motivational gym content"
+    ],
+    "scroll_context": "2am to 4am on mandated 15-minute breaks in a freezing fulfillment center break room",
+    "attention_style": "Stops for fast-paced sports clips, 'day in my life' warehouse videos, or anything with Travis Scott; swipes away from slow tutorials, podcast clips with no visuals, or corporate 'we're a family' content",
+    "description": "Darnell walks 12 miles a night pulling orders and uses his two breaks to mentally escape the warehouse. He watches standing up, phone propped on a vending machine, often with a dead arm from repetitive strain. He shares videos with his shift group chat but never comments—too tired to type.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_16",
+    "name": "Helena",
+    "age": 34,
+    "location": "São Paulo, Brazil",
+    "occupation": "Stay-at-home parent",
+    "interests": [
+      "toddler meal hacks",
+      "small space organizing",
+      "Brazilian soap clips",
+      "mom comedy"
+    ],
+    "scroll_context": "Nursing her 8-month-old at 2am, 4am, and 6am, phone brightness at minimum, one-handed scrolling",
+    "attention_style": "Stops for silent or captioned content she can follow without sound, relatable mom exhaustion, or clever household shortcuts; swipes away from crying baby sounds, perfect mom influencers, or anything requiring headphones",
+    "description": "Helena hasn't slept more than three hours straight in months. She watches videos to feel less alone during night feeds, favoring raw, unfiltered mom content over polished family vlogs. She saves organizing hacks she'll never try and sends funny clips to her partner sleeping in the next room.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_17",
+    "name": "Kenji",
+    "age": 17,
+    "location": "Osaka, Japan",
+    "occupation": "High school student",
+    "interests": [
+      "vintage fashion hauls",
+      "horror game playthroughs",
+      "cute animal accounts",
+      "study-with-me videos"
+    ],
+    "scroll_context": "Back corner of math class, phone flat on desk under a strategically placed pencil case, volume permanently off",
+    "attention_style": "Stops for visually striking thrift flips, cryptic horror shorts with text overlays, or anything with Scottish Fold cats; swipes away from teachers explaining things, talking-head rants, or videos with essential audio",
+    "description": "Kenji is failing math but has perfect attendance because school is where he socializes and scrolls. He's developed elite peripheral vision for detecting teacher movement. He never likes or comments—too risky—but maintains elaborate saved folders organized by mood.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_18",
+    "name": "Margaret",
+    "age": 64,
+    "location": "Glasgow, UK",
+    "occupation": "Retired postal worker",
+    "interests": [
+      "gardening tips",
+      "funny dog videos",
+      "local history",
+      "easy crafts"
+    ],
+    "scroll_context": "10pm to midnight in bed after her granddaughter showed her the app, tablet propped on knees, reading glasses on",
+    "attention_style": "Stops for clear, well-lit videos with slow speech or good captions, Scottish creators, or anything reminding her of her dog; swipes away from rapid cuts, slang she doesn't understand, or videos with no clear point",
+    "description": "Margaret joined to see what her granddaughter keeps laughing at and now spends an hour nightly falling down rabbit holes. She double-taps constantly thinking she's bookmarking, accidentally follows hundreds of accounts, and once commented 'lovely' on a video about divorce. She prefers YouTube Shorts because the interface confuses her less.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_19",
+    "name": "Omar",
+    "age": 42,
+    "location": "Cairo, Egypt",
+    "occupation": "Uber driver",
+    "interests": [
+      "political satire",
+      "car maintenance hacks",
+      "Egyptian comedy sketches",
+      "Quran recitation"
+    ],
+    "scroll_context": "Parked outside airports and malls waiting for ride requests, phone mounted on dash, 5-15 minute intervals",
+    "attention_style": "Stops for sharp political jokes, money-saving driver tips, or emotional fatherhood content; swipes away from anything sexually suggestive (passengers might see), fake news he recognizes, or English without Arabic captions",
+    "description": "Omar drives 10-hour shifts and knows every free parking spot near Cairo International. He watches between rides to stay alert, not relax—he avoids anything too absorbing. He forwards political clips to his brother's WhatsApp and argues in comment sections under regional news accounts. His algorithm is a mess of interests.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_20",
+    "name": "Svetlana",
+    "age": 29,
+    "location": "Riga, Latvia",
+    "occupation": "Hairdresser",
+    "interests": [
+      "color transformation videos",
+      "true crime summaries",
+      "Baltic travel",
+      "ASMR hair sounds"
+    ],
+    "scroll_context": "Between clients in her salon chair, phone on the station counter, 10-40 minute gaps depending on bookings",
+    "attention_style": "Stops for satisfying before/after color jobs, quick true crime 'this happened in my town' stories, or Latvian creators; swipes away from bad hair advice, lengthy unboxings, or content in Russian (political choice since 2022)",
+    "description": "Svetlana's salon has spotty WiFi so she downloads videos during slow mornings. She watches with clients sometimes—'look at this crazy color correction'—turning scrolling into small talk. She critiques every hair video professionally and has strong opinions about which 'hairdressers' are actually licensed.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_21",
+    "name": "Diego",
+    "age": 22,
+    "location": "Lima, Peru",
+    "occupation": "Backpacker / hostel worker",
+    "interests": [
+      "budget travel hacks",
+      "language learning content",
+      "Peruvian food abroad",
+      "van life failures"
+    ],
+    "scroll_context": "14-hour bus rides between cities, phone battery conserved, downloaded content or spotty data",
+    "attention_style": "Stops for realistic broke travel stories, Spanish-English code-switching, or South American creators; swipes away from luxury travel, 'quit your job' preachiness, or content assuming everyone has passports from privileged countries",
+    "description": "Diego works hostel reception for room and board while figuring out his next move. He scrolls to research destinations and feel connected to home. He saves videos of Peruvian restaurants in cities he might visit and sends them to his mom. Motion sickness limits his scrolling on winding mountain roads.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_22",
+    "name": "Aisha",
+    "age": 38,
+    "location": "Minneapolis, USA",
+    "occupation": "Small business owner (halal grocery)",
+    "interests": [
+      "small business motivation",
+      "Somali cooking tutorials",
+      "debt-free journeys",
+      "immigrant success stories"
+    ],
+    "scroll_context": "11pm to 1am after closing the store, doing inventory in the back office, procrastinating on QuickBooks",
+    "attention_style": "Stops for honest business struggles, East African creators, or practical accounting tips disguised as motivation; swipes away from 'hustle harder' content from trust-fund entrepreneurs, complicated transitions, or anything wasting her limited time",
+    "description": "Aisha's family store is finally profitable after five years and she's terrified of messing up the books. She watches business content to feel less alone in the stress, not for actual advice—she's learned most of it doesn't apply to cash-heavy, family-staffed operations. She watches at 1.5x speed always.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_23",
+    "name": "Wei",
+    "age": 31,
+    "location": "Wuhan, China",
+    "occupation": "Factory quality inspector",
+    "interests": [
+      "factory worker diaries",
+      "cheap gadget reviews",
+      "rural life content",
+      "comedy skits"
+    ],
+    "scroll_context": "12-hour shifts with two 30-minute breaks in a dormitory room shared with three others, headphones essential",
+    "attention_style": "Stops for other factory workers documenting their real days, absurdly cheap tool demonstrations, or nostalgic rural Spring Festival content; swipes away from office worker complaints, expensive products, or anything feeling like propaganda",
+    "description": "Wei inspects circuit boards and uses breaks to decompress, not think. He prefers content from people with similar lives over aspirational escapes—seeing someone else exhausted in a uniform feels more relaxing than beaches. He comments rarely but meaningfully, usually correcting technical details in gadget videos.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_24",
+    "name": "Yuki",
+    "age": 27,
+    "location": "Auckland, New Zealand",
+    "occupation": "Graduate student (marine biology)",
+    "interests": [
+      "ocean facts",
+      "thesis procrastination memes",
+      "New Zealand nature",
+      "academic twitter crossovers"
+    ],
+    "scroll_context": "10am to 2pm at her desk with thesis document open but minimized, guilt-scrolling between attempts to write",
+    "attention_style": "Stops for marine content that feels relevant to her work, relatable PhD struggle posts, or local NZ creators; swipes away from 'just do it' motivation, anything reminding her of her advisor, or ocean content with bad science she can't resist correcting",
+    "description": "Yuki's been 'almost done' with her thesis for eight months. She tells herself she's 'researching engagement strategies' when she scrolls, but she's just avoiding. She keeps a separate account for following actual scientists so her main feed stays distractingly fun. She has 200 drafts of comments she never posted.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_25",
+    "name": "Björn",
+    "age": 53,
+    "location": "Östersund, Sweden",
+    "occupation": "Farmer (crop and small livestock)",
+    "interests": [
+      "tractor restoration",
+      "weather forecasts",
+      "Nordic noir clips",
+      "sheep dog videos"
+    ],
+    "scroll_context": "November through March during off-season, mornings with coffee, 30-60 minutes before the day's maintenance tasks",
+    "attention_style": "Stops for practical machinery repair, deadpan Scandinavian humor, or working dog content; swipes away from urban farming idealism, fast fashion, or anything with false urgency—he has enough real deadlines",
+    "description": "Björn only downloaded the app last winter when his nephew insisted. He uses it seasonally, intensely curious during dark months, barely touching his phone during planting and harvest. He doesn't understand most trends but appreciates the algorithm learning he wants tractor content, not dances. He forwards videos to his farming cooperative's email chain.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_26",
+    "name": "Thandi",
+    "age": 46,
+    "location": "Johannesburg, South Africa",
+    "occupation": "High school teacher",
+    "interests": [
+      "teacher humor",
+      "education policy debates",
+      "gospel music clips",
+      "home renovation"
+    ],
+    "scroll_context": "8pm to 10pm after lesson planning is technically done, in bed with grading still pending, phone as reward",
+    "attention_style": "Stops for teachers accurately depicting classroom chaos, South African creators, or satisfying home before/afters; swipes away from 'teachers are lazy' content, American classroom culture that doesn't translate, or anything using her students' slang incorrectly",
+    "description": "Thandi has taught for twenty years and uses videos to remember why she chose this. She follows younger teachers documenting their first years with complicated emotions—proud they're sharing, worried they're burning out. She never posts but has strong opinions about which teacher creators are actually in classrooms versus performing teaching.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_27",
+    "name": "Jin-ho",
+    "age": 58,
+    "location": "Busan, South Korea",
+    "occupation": "Long-haul truck driver",
+    "interests": [
+      "truck stop food reviews",
+      "baseball highlights",
+      "trot music",
+      "dashcam compilations"
+    ],
+    "scroll_context": "Rest stops every four hours by law, 45-minute breaks at highway service areas, phone charging in the cab",
+    "attention_style": "Stops for other Korean truckers documenting their routes, Lotte Giants highlights he missed while driving, or nostalgic trot performances; swipes away from car crash videos (too real), anything requiring sustained attention, or content making fun of drivers",
+    "description": "Jin-ho drives Seoul to Busan and back three times weekly, living in his truck cab. He watches to feel connected during solitary days, favoring content that acknowledges his world exists. He comments simple encouragements on younger drivers' videos and has been recognized twice at rest stops by viewers of his rare dashcam uploads.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_28",
+    "name": "Diego",
+    "age": 22,
+    "location": "Guadalajara, Mexico",
+    "occupation": "call center agent",
+    "interests": [
+      "fútbol",
+      "memes",
+      "true crime",
+      "cheap recipes"
+    ],
+    "scroll_context": "Between back-to-back customer calls, hiding phone under desk during dead air moments",
+    "attention_style": "Stops for relatable workplace rage or Mexican family dynamics; swipes past English-only content without subtitles or corporate motivational speeches",
+    "description": "Diego works 10-hour shifts in a cubicle farm handling US insurance claims. His supervisor monitors screen time, so he keeps TikTok in a tiny window, scrolling only during the 90-second gaps between calls. He craves videos that validate how much he hates his job without explicitly saying so.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_29",
+    "name": "Aisha",
+    "age": 31,
+    "location": "Lagos, Nigeria",
+    "occupation": "bank teller",
+    "interests": [
+      "Nollywood gossip",
+      "hairstyle tutorials",
+      "real estate investing",
+      "church drama"
+    ],
+    "scroll_context": "During her 45-minute lunch break in the bank's cramped break room, sitting on a plastic chair",
+    "attention_style": "Stops for Nigerian family skits and transformation videos; swipes past anything requiring headphones or slow-burn storytelling",
+    "description": "Aisha has exactly 45 minutes to eat her jollof rice and escape her standing-all-day reality. She scrolls aggressively, needing immediate payoff—no slow pans, no 'wait for it' captions. She shares videos in her WhatsApp family group without watching to the end, trusting the first 3 seconds.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_30",
+    "name": "Björn",
+    "age": 54,
+    "location": "Gothenburg, Sweden",
+    "occupation": "maritime welder",
+    "interests": [
+      "fishing techniques",
+      "machinery restoration",
+      "dark humor",
+      "70s rock"
+    ],
+    "scroll_context": "In his bunk on offshore oil platforms during 2-week rotations, limited satellite bandwidth",
+    "attention_style": "Stops for satisfying mechanical processes or deadpan Scandinavian comedy; swipes past influencer lifestyle content and anything with jump cuts every 0.5 seconds",
+    "description": "Björn spends two weeks at a time on a floating rig in the North Sea. The shared WiFi is expensive and slow, so he downloads videos during port leave and watches offline. He has zero patience for performative emotion—if someone is crying on camera within 3 seconds, he's gone.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_31",
+    "name": "Priya",
+    "age": 19,
+    "location": "Mumbai, India",
+    "occupation": "MBBS first-year student",
+    "interests": [
+      "medical memes",
+      "K-drama clips",
+      "study motivation",
+      "Mumbai street food"
+    ],
+    "scroll_context": "Propped against her hostel pillow at 1 AM, phone on 5% battery, avoiding tomorrow's anatomy cramming",
+    "attention_style": "Stops for 'day in my life as a medical student' content or anything in Hindi she can half-watch; swipes past English science explainers that feel like more studying",
+    "description": "Priya's hostel roommate is asleep, so she scrolls with brightness at minimum and no sound. She's guilt-scrolling—every video is a procrastination she'll regret. She saves 'motivational' videos she never re-watches, collecting them like talismans against her mounting syllabus.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_32",
+    "name": "Tyrone",
+    "age": 36,
+    "location": "Memphis, USA",
+    "occupation": "FedEx package handler",
+    "interests": [
+      "basketball highlights",
+      "grilling tutorials",
+      "relationship advice",
+      "Memphis rap"
+    ],
+    "scroll_context": "On the 15-minute morning break, sitting on a concrete ledge in the loading dock, back killing him",
+    "attention_style": "Stops for athletic feats or straight-talk relationship clips; swipes past soft-spoken ASMR or anything requiring him to read on-screen text in sunlight",
+    "description": "Tyrone's break is timed to the minute—late return means dock supervisor writes him up. He scrolls standing, phone angled against the glare, needing content that works without sound in a roaring warehouse zone. He's a lurker, never commenting, but sends links to his brother's DMs.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_33",
+    "name": "Svetlana",
+    "age": 47,
+    "location": "Minsk, Belarus",
+    "occupation": "kindergarten teacher",
+    "interests": [
+      "dacha gardening",
+      "Soviet nostalgia",
+      "cheap crafts",
+      "medical symptom checking"
+    ],
+    "scroll_context": "After 7 PM, collapsed on her Soviet-era sofa, legs elevated, finally quiet after 30 six-year-olds",
+    "attention_style": "Stops for practical household tips or Eastern European cultural references; swipes past teenage trends, fast fashion hauls, or anything sexually suggestive",
+    "description": "Svetlana downloaded Instagram because her daughter insisted, still confuses Reels with Stories. She scrolls slowly, often watching the same video twice because she missed it the first time. She forwards 'useful' videos to her entire contact list regardless of relevance, proud of her digital literacy.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_34",
+    "name": "Jamal",
+    "age": 26,
+    "location": "London, UK",
+    "occupation": " Deliveroo cyclist",
+    "interests": [
+      "UK drill music",
+      "bike maintenance",
+      "free food hacks",
+      "football transfer rumors"
+    ],
+    "scroll_context": "Between orders, phone mounted on handlebars, paused at traffic lights in the rain",
+    "attention_style": "Stops for London-specific content or 20-second bike tricks; swipes past anything over 60 seconds or requiring both hands to engage",
+    "description": "Jamal's income depends on response time, so his scrolling is literally between red lights. He watches videos one-handed, thumb hovering to pause if the light changes. He never reads captions—can't, while cycling—and relies entirely on audio and immediate visual hooks.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_35",
+    "name": "Hana",
+    "age": 29,
+    "location": "Seoul, South Korea",
+    "occupation": "hagwon English instructor",
+    "interests": [
+      "true crime psychology",
+      "single life in Seoul",
+      "English learning content",
+      "cafe vlogs"
+    ],
+    "scroll_context": "On the last subway home at 11 PM, crushed in a car, holding phone at chest level to avoid eye contact",
+    "attention_style": "Stops for bilingual content she can practice with or 'honest talk about being 30 and unmarried'; swipes past baby videos (too painful) and anything with exaggerated aegyo",
+    "description": "Hana teaches until 10 PM six days a week, her social life eroded by hagwon hours. She scrolls to feel less alone in the crowd, seeking content that acknowledges the specific exhaustion of Korean millennials without explicitly naming it. She comments rarely but meaningfully, usually at 2 AM.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_36",
+    "name": "Omar",
+    "age": 62,
+    "location": "Cairo, Egypt",
+    "occupation": "retired army mechanic",
+    "interests": [
+      "classic Arabic poetry",
+      "mechanical repairs",
+      "Egyptian political satire",
+      "grandchildren's achievements"
+    ],
+    "scroll_context": "5-7 AM on his balcony before heat builds, mint tea cooling, reading glasses on and off",
+    "attention_style": "Stops for elderly Egyptian men discussing life or engine restoration; swipes past rapid editing, English-only content, or anything with music he doesn't recognize",
+    "description": "Omar's grandson installed TikTok and set it to Arabic. He treats it like television, watching slowly, often replaying, sometimes asking his wife what a slang word means. He doesn't understand the scroll economy—he'll watch a boring video to the end out of politeness, confusing the algorithm terribly.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_37",
+    "name": "Chloe",
+    "age": 17,
+    "location": "Auckland, New Zealand",
+    "occupation": "Year 13 student, part-time supermarket checkout",
+    "interests": [
+      "NZ indie music",
+      "climate anxiety content",
+      "thrift flips",
+      "mental health realism"
+    ],
+    "scroll_context": "Under the desk in statistics class, phone on lap, one earbud hidden under hair",
+    "attention_style": "Stops for authentic 'unhinged' rants or environmental action content; swipes past polished influencer perfection or anything that feels like homework",
+    "description": "Chloe's school banned phones but enforcement is uneven. She scrolls as rebellion and sedation, seeking content that validates her dread about the future without offering solutions she's too tired to execute. She reports videos that feel 'fake' out of spite, her only platform interaction.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_38",
+    "name": "Rajesh",
+    "age": 41,
+    "location": "Dubai, UAE",
+    "occupation": "supermarket warehouse supervisor",
+    "interests": [
+      "Malayalam cinema",
+      "Gulf worker life",
+      "money transfer tips",
+      "Kerala news"
+    ],
+    "scroll_context": "In a labor camp bunk bed, 8 PM, after 12-hour shift in -20°C cold storage, sharing data with 5 roommates",
+    "attention_style": "Stops for Malayalam content or Gulf migrant worker solidarity; swipes past Arabic content he can't read or anything reminding him of Dubai luxury he'll never access",
+    "description": "Rajesh's phone is his window to Kerala, 3,000 kilometers and most of his income away. He scrolls horizontally through his Following feed, rarely Explore—he curates carefully, avoiding content that triggers the specific grief of separation. He video-calls home Sunday mornings, then scrolls their sent videos the rest of the week.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_39",
+    "name": "Ingrid",
+    "age": 58,
+    "location": "Oslo, Norway",
+    "occupation": "disability pensioner, former librarian",
+    "interests": [
+      "slow TV",
+      "knitting patterns",
+      "disability advocacy",
+      "Nordic noir"
+    ],
+    "scroll_context": "Mid-morning in her adapted apartment, waiting for home care visit, world narrowed to screen size",
+    "attention_style": "Stops for genuine disability representation or extremely slow-paced craft content; swipes past inspiration porn, 'overcoming' narratives, or anything shaming dependency",
+    "description": "Ingrid's chronic pain limits her to approximately 3 meters of movement. Short-form video isn't entertainment—it's her primary social contact, her window, her proof that others exist. She scrolls slowly, often crying at mundane content, not from sadness but from the relief of witnessing life continue elsewhere.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_40",
+    "name": "Wei",
+    "age": 24,
+    "location": "Shenzhen, China",
+    "occupation": "Foxconn assembly line technician",
+    "interests": [
+      "factory worker influencers",
+      "budget tech reviews",
+      "hometown cooking",
+      "sleep ASMR"
+    ],
+    "scroll_context": "In a 12-person dormitory, 10:30 PM lights-out, under blanket with brightness minimum, exhausted",
+    "attention_style": "Stops for 'day in factory life' content or audio-only sleep aids; swipes past anything requiring engagement, commenting, or emotional labor she doesn't have left",
+    "description": "Wei's 10-hour shifts involve 4,000 identical motions. Her scrolling is pre-sleep anesthesia, not entertainment—she often falls asleep mid-video, phone on her chest, waking to a dead battery and algorithmic chaos. She never comments, never posts, exists in the data as pure consumption pattern.",
+    "weight": 1.0
+  },
+  {
+    "persona_id": "persona_41",
+    "name": "Fatima",
+    "age": 34,
+    "location": "Casablanca, Morocco",
+    "occupation": "hairdresser, home salon",
+    "interests": [
+      "protective hairstyles",
+      "Darija comedy",
+      "client drama stories",
+      "halal cooking shortcuts"
+    ],
+    "scroll_context": "Between appointments, dye processing under plastic caps, phone propped on styling station",
+    "attention_style": "Stops for Moroccan family skits or hairstyle tutorials she can actually use; swipes past French-only content (colonial residue she resents) or anything requiring sound while clients are present",
+    "description": "Fatima's salon is her living room—clients come to her, children underfoot, husband in the next room. She scrolls in fragmented 4-minute intervals, never knowing when someone will arrive. She's learned to pause videos mid-sentence without losing track, a skill born of constant interruption.",
+    "weight": 1.0
+  }
+]

--- a/docs/homework/project-management-report.md
+++ b/docs/homework/project-management-report.md
@@ -1,0 +1,63 @@
+# Flair2 — Project Management Report
+
+**Team:** Sam Wu (@0b00101111) · Jess Zhang (@tyrahappy)
+**Duration:** 2026-03-22 → 2026-04-18 (~4 weeks)
+**Scope:** 262 commits · 112 merged PRs · 2 deployed services on AWS
+
+---
+
+## From Design to Final State
+
+We started from a V1 hackathon prototype (`gemini-social-asset`) and rewrote it with engineering rigor: spec-first, TDD, CI/CD, two-service AWS architecture. Initial design decomposed the problem into six pipeline stages (S1–S6) and five milestones (M1–M5) planned on a parallel-track timeline.
+
+```
+ V1 prototype               V2 engineered system              Deployed
+ ───────────────────────────────────────────────────────────────────────
+ Monolithic main.py   →   modular (api/pipeline/workers)   →   ECS Fargate
+ In-memory state      →   Redis + Celery coordination       →   ElastiCache
+ Sequential pipeline  →   MapReduce fan-out/fan-in          →   20 concurrent
+ Gemini only          →   pluggable provider registry       →   Kimi live
+ No tests / CI        →   111 unit + 5 integration + M5/M6  →   GitHub Actions
+```
+
+## Work Breakdown (Parallel Tracks)
+
+| Week | Sam (frontend + pipeline stages) | Jess (infra + distributed systems) | Sync point |
+|------|----------------------------------|-------------------------------------|------------|
+| Mar 22–28 | **M1** — stage functions S1–S6, first real pipeline run | **M2** — Terraform: VPC, ECS, ElastiCache, DynamoDB, S3 | Interface contract (issue #71) |
+| Mar 28–Apr 4 | **M4** scaffold — Astro, create page | **M2** finish + **M3** — Celery, orchestrator, rate limiter | Contract #71 §3 — API routes |
+| Apr 4–8 | **M4** — SSE pipeline visualizer, voting animation | **M3** — SSE manager, checkpoints, multi-user validation | Contract #71 §2 — SSE events |
+| Apr 8–11 | **M4** — results page, polish | **M3-5** — integration tests, deploy workflow | First full E2E on AWS |
+| Apr 11–15 | Experiments helper, design-language port | **M5** — M5-1/2/3 backpressure, recovery, cache experiments | Both: M5-4 Locust, M6 ElastiCache |
+| Apr 15–18 | S1 grid viz, S4 vote matrix, observability | Deploy hardening, Terraform state import, destroy workflow | Final polish |
+
+**PR split:** Sam 69 (62%), Jess 43 (38%). Every PR reviewed by the other.
+
+## Problems Encountered & How We Broke Them Down
+
+| # | Problem | How we found it | Resolution |
+|---|---------|-----------------|------------|
+| 1 | **Gemini intermittent 500s + rate limits** | First production run failed at S3 | Built provider registry → switched to Kimi in one PR (#95) |
+| 2 | **Docker image missing dataset** — S1 500'd on every start | Frontend showed "Pipeline failed" with no worker activity | 4 PRs to root-cause: `.dockerignore` excluded `data/` (#102, #109, #125, #126) |
+| 3 | **Kimi OpenAI-compatible shim deprecated** — all requests returned a misleading "temperature" error | Tests passed locally, production 400s | Migrated `KimiProvider` from OpenAI SDK → Anthropic Messages API |
+| 4 | **Celery workers never registered tasks** — pipeline silently hung at `stage_started` | 2 events in SSE then nothing; only traceable via CloudWatch | One-line fix: `import app.workers.tasks` in `celery_app.py` (#140) |
+| 5 | **Frontend faked progress when backend was stuck** | Stages showed "running" with no real work | Added single-writer event discipline, 30s stall detector with API probe (#136, #138) |
+| 6 | **Terraform state drift after CI change** | "ELB already exists" on every `terraform apply` | Wrote idempotent import workflow + script (#162) — discovers each resource by tag/name and imports ~50 resources |
+| 7 | **Kimi concurrency 429s killed S4** at ~40 personas | Pipeline visibly failed with "rate limited" even though daily quota was at 1% | Two-layer fix: RedisSemaphore (cap at 29 in-flight) + retry-budget-per-error-class with 8/20/45/90s backoff + jitter (#164) |
+| 8 | **One bad video killed whole S1 run** | Sparse TikTok transcripts hit schema validation | Skip-and-continue (#156): mark video skipped, let S2 aggregate the rest |
+| 9 | **Stragglers (99/100) hung pipeline** because of long retry budget | UI showed "Pipeline appears stalled" at 99/100 | 95% completion threshold with SETNX-guarded transition (#165) |
+| 10 | **S3 client-side routes 404'd** after deploy — "Start Pipeline" bounced to home page | User-reported | S3 error doc only serves ROOT index.html; switched path-based routes to query params (#134) |
+
+## Process Discipline That Held
+
+- **Interface contract (issue #71) upfront** — documented every Redis key, every SSE event, every API endpoint. Let Sam and Jess work independently for weeks and integrate cleanly.
+- **One PR, one fix** — 112 PRs averaged 4 files each. Every PR title used conventional prefixes (`feat:`, `fix:`, `chore:`, `docs:`) for grep-friendly history.
+- **Branch protection + mandatory review** — never pushed to main; every PR reviewed by the other team member before merge.
+- **Tests before features** — 105 unit tests existed before the first real pipeline run. Grew to 111 by the end. Caught the `RateLimitError` retry countdown bug pre-deploy.
+- **Test the failure paths explicitly** — M5-2 (failure recovery) validated the checkpoint-and-resume code before we ever needed it. Saved ~50% of LLM calls on the first real crash.
+
+## What the Final State Runs
+
+**AWS** `314727362981` / `us-west-2`: VPC, 2 public + 2 private subnets, ECS Fargate cluster (API + Worker services, 2–6 / 2–4 tasks with autoscaling), ElastiCache Redis, ALB, S3 static site, DynamoDB, ECR, IAM roles — all Terraform-managed.
+**CI/CD:** GitHub Actions runs lint+test on every push; merges to main auto-deploy Docker image → ECR → ECS and static site → S3.
+**Pipeline:** 100 real viral TikTok videos analyzed in ~15s (20 concurrent workers, bounded by Kimi's concurrency semaphore), 20 scripts generated on-niche, 42 predefined personas vote, top 10 personalized per creator profile.

--- a/docs/homework/project-management-report.md
+++ b/docs/homework/project-management-report.md
@@ -52,7 +52,7 @@ We started from a V1 hackathon prototype (`gemini-social-asset`) and rewrote it 
 
 - **Interface contract (issue #71) upfront** — documented every Redis key, every SSE event, every API endpoint. Let Sam and Jess work independently for weeks and integrate cleanly.
 - **One PR, one fix** — 112 PRs averaged 4 files each. Every PR title used conventional prefixes (`feat:`, `fix:`, `chore:`, `docs:`) for grep-friendly history.
-- **Branch protection + mandatory review** — never pushed to main; every PR reviewed by the other team member before merge.
+- **Hard branch protection on `main`** — Sam and Jess set a GitHub ruleset that *physically blocks* direct pushes and requires ≥1 approving review from the other team member before merge (admin override disabled). This turned "we should review each other's work" from a norm into an enforced gate. Effect: every one of the 112 merged PRs has at least one reviewer's signature; neither of us can ship without the other reading the diff. On multiple occasions Jess's review caught issues Sam missed (and vice-versa) before they hit production.
 - **Tests before features** — 105 unit tests existed before the first real pipeline run. Grew to 111 by the end. Caught the `RateLimitError` retry countdown bug pre-deploy.
 - **Test the failure paths explicitly** — M5-2 (failure recovery) validated the checkpoint-and-resume code before we ever needed it. Saved ~50% of LLM calls on the first real crash.
 

--- a/docs/lessons/02-the-deployed-architecture.md
+++ b/docs/lessons/02-the-deployed-architecture.md
@@ -4,7 +4,7 @@
 
 ## A note on honesty
 
-The original architecture doc (`design/architecture.md`) says the backend deploys to Railway and the frontend to Cloudflare Pages. In reality, the backend runs on AWS ECS Fargate with ElastiCache Redis, and the frontend is an S3 static website. The Gemini API is mentioned throughout the design docs and experiment reports — in reality, the production provider is Kimi (Moonshot AI), accessed through an OpenAI-compatible endpoint. The architecture doc hasn't been updated.
+The original architecture doc (`design/architecture.md`) says the backend deploys to Railway and the frontend to Cloudflare Pages. In reality, the backend runs on AWS ECS Fargate with ElastiCache Redis, and the frontend is an S3 static website. The Gemini API is mentioned throughout the design docs and experiment reports — in reality, the production provider is Kimi (Moonshot AI), accessed over Kimi's coding endpoint using the Anthropic Messages API. The architecture doc hasn't been updated.
 
 This is the single most common documentation failure in software: **design docs freeze at the point they were written.** Always verify against the code and the infrastructure. `git log`, `grep`, and `terraform plan` are more trustworthy than any markdown file.
 
@@ -42,8 +42,8 @@ This article describes the real system as of April 2026, verified against code a
                     └────────┬───────┘
                              │
                     ┌────────┴────────┐
-                    │    Kimi API     │  OpenAI-compatible LLM
-                    │ (Moonshot AI)   │  via OpenAI Python SDK
+                    │    Kimi API     │  Anthropic Messages API
+                    │ (Moonshot AI)   │  via anthropic Python SDK
                     └─────────────────┘
 
 
@@ -110,9 +110,9 @@ This article describes the real system as of April 2026, verified against code a
 **File:** `backend/app/providers/kimi.py`
 **File:** `backend/app/providers/registry.py`
 
-**How it connects:** Kimi exposes an OpenAI-compatible API. The `KimiProvider` class uses the official OpenAI Python SDK with a custom `base_url` and a `default_headers` override for User-Agent (Kimi requires this). This is a common pattern — many LLM providers ship OpenAI-compatible endpoints so existing client code works with a base URL swap.
+**How it connects:** Kimi's coding endpoint speaks the **Anthropic Messages API** at `/coding/v1/messages`. The `KimiProvider` uses the `AsyncAnthropic` client with `base_url="https://api.kimi.com/coding"` and a `default_headers` override for User-Agent (Kimi's endpoint whitelists approved coding agents — Claude Code, Kimi CLI, etc.). An earlier version of the endpoint spoke OpenAI's `chat/completions` schema; that surface went dead in early 2026 and we migrated to Anthropic's SDK. See [Article 15](15-kimi-and-openai-compatibility.md) for the migration story.
 
-**The migration story:** The system was originally built for Gemini. PR #95 ("chore: remove Gemini secret requirement, Kimi-only deployment") made the switch. Because the provider was behind a registry abstraction (`providers/registry.py`), the migration was a configuration change, not a code rewrite. The `GeminiProvider` class still exists in the codebase — it's just not wired up in production.
+**The migration stories:** Plural, now. First Gemini → Kimi (PR #95: "remove Gemini secret requirement"), driven by Gemini's intermittent 500s and rate-limit issues. Then OpenAI SDK → Anthropic SDK, driven by Kimi deprecating their OpenAI-compatible shim. Both migrations only touched `providers/kimi.py` because every stage calls through the `ReasoningProvider` Protocol. The `GeminiProvider` class still exists; it's just not wired up in production.
 
 ### Frontend (Astro + React on S3)
 

--- a/docs/lessons/05-sse-and-redis-streams.md
+++ b/docs/lessons/05-sse-and-redis-streams.md
@@ -157,14 +157,21 @@ The orchestrator publishes these events to the stream (via `XADD`):
 |-------|------|------|
 | `pipeline_started` | Run begins | `run_id`, `total_videos`, `total_personas`, `top_n` |
 | `stage_started` | Each stage begins | `stage` name, `total_items` |
-| `s1_progress` | Each video analyzed | `video_id`, `completed`, `total` |
+| `s1_task_started` | A worker picks up an S1 task (before LLM call) | `video_id`, `description` (snippet) |
+| `s1_progress` | Each video analyzed | `video_id`, `completed`, `total`, `hook_type`, `pacing`, `trigger_count` |
+| `s1_video_skipped` | One video un-analyzable after retries exhausted | `video_id`, `reason`, `completed`, `total` |
 | `s2_complete` | Aggregation done | `pattern_count` |
-| `s3_complete` | Generation done | `script_count` |
-| `vote_cast` | Each persona votes | `persona_id`, `top_5`, `completed`, `total` |
+| `s3_progress` | Each script generated (sequential) | `script_id`, `completed`, `total` |
+| `s3_complete` | Generation done | `script_count`, `script_ids` |
+| `s4_task_started` | A worker picks up a vote task | `persona_id`, `name`, `age`, `location`, `occupation`, `description` |
+| `vote_cast` | Each persona votes | `persona_id`, `persona_name`, `persona_description`, `top_5`, `completed`, `total` |
 | `s5_complete` | Ranking done | `top_ids`, `top_n` |
 | `s6_progress` | Each script personalized | `script_id`, `completed`, `total` |
 | `pipeline_completed` | Run finished | `run_id`, `result_count` |
 | `pipeline_error` | Run failed | `stage`, `error`, `recoverable` |
+| `pipeline_recovered` | Crash recovery replayed from S4 checkpoint | `run_id`, `s4_checkpoint`, `remaining_personas` |
+
+**The `*_task_started` pattern:** events fire the moment a worker picks up a task, *before* the LLM call. This is what drives the concurrency meters on the frontend — the S1 grid can show "8 cards pulsing" because it sees 8 `s1_task_started` events that haven't yet been followed by `s1_progress`. Without these events, the UI would jump cards straight from `pending` to `completed` and lose the "work in progress" state entirely.
 
 **Notice the pattern:** progress events for fan-out stages (S1, S4, S6) include `completed` and `total` counts. This lets the frontend show a progress bar: "Analyzing video 37 of 100" or "42 of 100 personas have voted." The frontend doesn't need to track state — each event carries enough context to render the current state.
 

--- a/docs/lessons/06-the-request-lifecycle.md
+++ b/docs/lessons/06-the-request-lifecycle.md
@@ -116,11 +116,13 @@ Each of the 2-4 Celery workers pulls `s1_analyze_task` messages from Redis db=1.
 done = await self._r.incr(f"run:{run_id}:s1:done")  # atomic increment
 ```
 
-This is the coordination mechanism. 100 workers might be completing S1 tasks concurrently. `INCR` is atomic in Redis — exactly one of them will see `done == 100` and trigger the transition to S2.
+This is the coordination mechanism. 100 workers might be completing S1 tasks concurrently. `INCR` is atomic in Redis — each caller gets a unique sequence number.
 
 The orchestrator publishes `s1_progress` events to the stream. The SSE manager picks them up. The browser shows: "Analyzed 1/100... 2/100... 42/100..."
 
-When `done >= config.num_videos`, the orchestrator calls `_transition_s2()`.
+**Completion threshold — 95%, not 100%.** Since a rate-limited task can retry for up to ~10 minutes (see [Article 16](16-rate-limiting.md)), waiting for every single task to finish would let one straggler gate the whole pipeline. The orchestrator's `_try_transition` helper fires when `done >= ceil(num_videos * 0.95)` — 95 of 100 for a full run. Late completers still `INCR` the counter; a SETNX guard on `run:{id}:s2:triggered` ensures the transition only fires once, even if multiple completions cross the threshold in the same millisecond. Skipped videos (from the [skip-and-continue path](09-worker-lifecycle-and-failure.md)) also count toward the threshold — one un-analyzable video doesn't block S2.
+
+For small runs (fewer than ~20 videos) the `ceil` rounds the threshold up to "all tasks," so the behavior matches the old all-or-nothing wait. The threshold only changes behavior at scale, which is exactly where stragglers bite.
 
 ## Phase 5: S2 — Reduce (aggregate patterns) (sub-second)
 

--- a/docs/lessons/09-worker-lifecycle-and-failure.md
+++ b/docs/lessons/09-worker-lifecycle-and-failure.md
@@ -33,9 +33,14 @@ The task function throws an error. Maybe Kimi returned unparseable JSON, or the 
 3. The task IS acknowledged (removed from the queue) — even with `acks_late=True`
 4. The exception is logged
 
-**In Flair2:** the task's error handler catches `ProviderError` and `StageError` and calls `orchestrator.on_failure()`, which marks the entire run as failed and publishes a `pipeline_error` event to the SSE stream. The user sees "Pipeline failed at S1: rate limit exceeded" in real time.
+**In Flair2:** the task's error handler catches `ProviderError` and `StageError`. What happens next depends on which stage failed:
 
-**Design choice:** Flair2 does NOT retry on exception by default. An LLM error that produced unparseable output is likely to produce unparseable output again. Instead, the run fails and the user can start a new one. This is a deliberate choice — automatic retry is appropriate for transient errors (network blip), not for semantic errors (bad LLM output).
+- **S1 (fan-out over videos):** the task calls `orchestrator.on_s1_skipped()` — mark this ONE video as un-analyzable, increment the same counter as a successful analysis, publish `s1_video_skipped` to the SSE stream. The other 99 videos keep going. This is the **skip-and-continue** pattern: one bad input should never kill the whole run.
+- **S2, S3, S5, S6:** these are single-task (S2/S3/S5) or small fan-outs (S6) where there's no useful notion of "continue without this one." The task calls `orchestrator.on_failure()`, which marks the run as failed and publishes `pipeline_error`.
+
+The difference is surface area. With 100 S1 tasks, the probability of at least one hitting a weird LLM response approaches 1 as N grows. Killing the run every time would make the system unusable at scale. With 1 S3 task, there's nothing to fall back to — if S3 fails, there are no scripts to vote on.
+
+**Design choice:** Flair2 retries transient errors at the provider level (3 attempts with backoff, 4 more for rate limits — see [Article 16](16-rate-limiting.md)) and the Celery task level (5 attempts with jitter) before giving up. Only after all retries exhaust does the stage decide whether to skip (S1) or fail the run (everything else).
 
 If you wanted automatic retry, Celery supports it:
 

--- a/docs/lessons/14-the-provider-abstraction.md
+++ b/docs/lessons/14-the-provider-abstraction.md
@@ -151,17 +151,17 @@ class KimiProvider:
 
     def _get_client(self):
         if self._client is None:
-            from openai import OpenAI
-            self._client = OpenAI(
+            from anthropic import AsyncAnthropic
+            self._client = AsyncAnthropic(
                 api_key=self._api_key,
-                base_url=KIMI_BASE_URL,
+                base_url=KIMI_BASE_URL,                        # "https://api.kimi.com/coding"
                 default_headers={"User-Agent": KIMI_USER_AGENT},
                 timeout=120.0,
             )
         return self._client
 ```
 
-Kimi uses the OpenAI Python SDK with a custom `base_url`. This is the **OpenAI-compatible API pattern** — covered in detail in [Article 15](15-kimi-and-openai-compatibility.md).
+Kimi speaks the **Anthropic Messages API** on its coding endpoint. We use the `AsyncAnthropic` client with a custom `base_url`. (An earlier version of Kimi spoke OpenAI's chat/completions schema instead — that surface went dead and the client had to migrate. [Article 15](15-kimi-and-openai-compatibility.md) covers the migration history and why the abstraction let us do it with a ~30-line change.)
 
 ### GeminiProvider (`providers/gemini.py`)
 

--- a/docs/lessons/15-kimi-and-openai-compatibility.md
+++ b/docs/lessons/15-kimi-and-openai-compatibility.md
@@ -1,40 +1,42 @@
-# 15. Kimi and the OpenAI Compatibility Layer
+# 15. Kimi and the Anthropic Messages Migration
 
-> Most new LLM providers ship an OpenAI-compatible API endpoint. Understanding why this pattern exists and how it works gives you a practical skill: swap LLM providers without rewriting client code.
+> Industry-standard APIs come and go. Between the hackathon prototype and today, Flair2 migrated its LLM client twice — first to OpenAI's chat/completions schema, then to Anthropic's Messages API. This article explains why both moves happened, what the current wiring looks like, and the transferable lesson about coding against an interface.
 
-## The industry pattern
+## Two migrations in one project
 
-OpenAI's Chat Completions API has become a de facto standard. The key endpoint:
+When the Kimi provider was first added, Kimi's coding endpoint exposed an OpenAI-compatible `chat/completions` route. That made integration cheap: use the OpenAI Python SDK, swap `base_url`, done. Many Chinese LLM providers did this to attract developers already using OpenAI's SDK.
 
+Then Kimi's endpoint quietly changed. The OpenAI-shaped route started returning a misleading error — `"only 0.6 is allowed for this model"` — for every request regardless of temperature. The real surface moved to an Anthropic Messages API shape at `/coding/v1/messages`. So we migrated again, this time to the Anthropic Python SDK.
+
+This sequence is now permanently documented in the provider file's docstring:
+
+```python
+"""Kimi (Moonshot AI) reasoning provider via the Anthropic Messages API.
+
+Kimi's coding endpoint migrated to an Anthropic-compatible schema
+(see /coding/v1/messages). The legacy OpenAI /chat/completions shim
+now returns a misleading "only 0.6 is allowed for this model" error
+for every request, regardless of temperature — a dead surface.
+"""
 ```
-POST /v1/chat/completions
-{
-  "model": "gpt-4",
-  "messages": [{"role": "user", "content": "Hello"}],
-  "max_tokens": 1000
-}
-```
 
-Many LLM providers — including Kimi (Moonshot AI), Together AI, Groq, Anyscale, Fireworks, and dozens of others — implement this exact API shape at their own endpoint. You can use the official OpenAI Python SDK, point it at a different `base_url`, and it works.
+**The transferable lesson:** LLM provider APIs are not stable contracts. Public pricing pages and "OpenAI compatible" claims can change month to month. Design your provider abstraction so migrations are one file's worth of work.
 
-**Why providers do this:** the OpenAI SDK is the most widely used LLM client library. By matching its API, providers get instant compatibility with every tool, framework, and tutorial that uses the OpenAI SDK. It's free adoption.
-
-**Why this matters for you:** if you build your LLM integration around the OpenAI SDK, switching providers is a configuration change (new base URL + API key), not a code rewrite.
-
-## How Kimi uses it
+## The current wiring
 
 **File:** `backend/app/providers/kimi.py`
 
 ```python
-KIMI_BASE_URL = "https://api.kimi.com/coding/v1"
-KIMI_MODEL = "kimi-for-coding/k2p5"
+KIMI_BASE_URL = "https://api.kimi.com/coding"  # no /v1 — SDK appends /v1/messages
+KIMI_MODEL = "kimi-for-coding"                 # or "kimi-k2.5"
 KIMI_USER_AGENT = "claude-code/0.1.0"
 
 class KimiProvider:
     def _get_client(self):
         if self._client is None:
-            from openai import OpenAI
-            self._client = OpenAI(
+            from anthropic import AsyncAnthropic
+
+            self._client = AsyncAnthropic(
                 api_key=self._api_key,
                 base_url=KIMI_BASE_URL,
                 default_headers={"User-Agent": KIMI_USER_AGENT},
@@ -43,160 +45,76 @@ class KimiProvider:
         return self._client
 ```
 
-Three things are swapped from the default OpenAI configuration:
+Three things changed from the OpenAI era:
 
-### 1. `base_url`
+### 1. Different SDK
 
-Instead of `https://api.openai.com/v1`, requests go to `https://api.kimi.com/coding/v1`. The SDK appends the endpoint path (`/chat/completions`) to this base URL. All request/response formatting stays the same.
+`AsyncAnthropic` instead of `OpenAI`. Same pattern (base_url + default_headers), different package. The rest of the provider code — retry logic, rate-limit handling, JSON parsing — didn't change because it doesn't depend on the SDK.
 
-### 2. `api_key`
+### 2. Different endpoint shape
 
-Kimi has its own API keys, separate from OpenAI. The key is passed to the same `api_key` parameter. The SDK includes it as a `Bearer` token in the `Authorization` header, which is the standard OAuth2 pattern.
+`base_url` stops at `/coding`, not `/coding/v1`, because the Anthropic SDK appends `/v1/messages` automatically. Getting this wrong silently breaks everything with a 404.
 
-### 3. `default_headers`
+### 3. Different request/response shape
 
-```python
-default_headers={"User-Agent": KIMI_USER_AGENT}
-```
+Requests use `client.messages.create(...)` with `messages=[...]` and `max_tokens` (required in Anthropic's API, optional in OpenAI's). Responses are `Message` objects with a `content` list of content blocks — each block has a `type` ("text", "tool_use", etc.) and a `text` attribute for text blocks.
 
-This is the interesting one. Kimi requires (or at least expects) a specific User-Agent header. The OpenAI SDK's default User-Agent is something like `openai-python/1.x.x`. Kimi might reject or rate-limit requests with that UA.
-
-The `default_headers` parameter on the OpenAI client adds these headers to every request. This is the workaround for provider-specific quirks that the standard API shape doesn't account for.
-
-**PR history:** this was fixed in PR #67 ("fix: use OpenAI default_headers for Kimi User-Agent"). Before that, the UA was being set some other way that didn't work reliably.
-
-## The API call
+Flair2 only cares about text, so it flattens the content blocks:
 
 ```python
-response = await asyncio.to_thread(
-    client.chat.completions.create,
-    model=self._model,
-    messages=[{"role": "user", "content": prompt}],
-    max_tokens=32768,
-)
-text = response.choices[0].message.content
+def _extract_text(response) -> str:
+    parts: list[str] = []
+    for block in response.content:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    return "".join(parts)
 ```
 
-**`asyncio.to_thread`:** the OpenAI Python SDK's synchronous client (`OpenAI`, not `AsyncOpenAI`) is used here, wrapped in `asyncio.to_thread` to avoid blocking the event loop. This runs the synchronous HTTP call in a thread pool.
+## The User-Agent whitelist (still required)
 
-**Why not `AsyncOpenAI`?** It would work too. The choice of sync-in-thread vs async is a pragmatic one — both work, sync is simpler to debug (stack traces are clearer), and the threading overhead is negligible for 2-5 second LLM calls.
+Kimi's coding endpoint is gated on User-Agent. Only approved coding agents (Kimi CLI, Claude Code, Roo Code, etc.) can use it. Unrecognized clients get 403: *"Kimi For Coding is currently only available for Coding Agents."*
 
-**Response parsing:** `response.choices[0].message.content` — the standard OpenAI response structure. Kimi returns responses in the same format: a list of `choices`, each with a `message` containing `role` and `content`.
+The `default_headers={"User-Agent": "claude-code/0.1.0"}` line is the whitelist workaround. Same fragility it had during the OpenAI era — if Kimi tightens validation, the spoof breaks. Nothing about migrating to Anthropic's SDK fixed this; it's an endpoint policy, not an SDK behavior.
 
-**Token usage:**
-```python
-if response.usage:
-    self.last_usage = {
-        "input_tokens": response.usage.prompt_tokens,
-        "output_tokens": response.usage.completion_tokens,
-    }
-```
+## The registry abstraction paid off twice
 
-The `usage` field is part of the OpenAI response spec. Kimi populates it. This lets Flair2 track token consumption across calls — useful for cost monitoring.
+Because every stage calls `provider.generate_text(...)` through the `ReasoningProvider` Protocol ([Article 14](14-the-provider-abstraction.md)), **two SDK migrations didn't touch any stage code.** S1, S3, S4, S6 have no idea which SDK sits behind the provider. The only files that changed across migrations:
 
-## Comparing with GeminiProvider
+- `providers/kimi.py` — the SDK wrapper
+- `pyproject.toml` — the dependency (anthropic instead of openai)
+- Tests that specifically asserted OpenAI SDK behavior
 
-Gemini does NOT use the OpenAI-compatible pattern. It has its own SDK:
+Every other part of the codebase — orchestrator, workers, stages, frontend — was unaffected. This is the dividend of programming to an interface. When the interface is stable and the implementation changes, only the implementation file changes.
 
-```python
-# Gemini — different SDK, different API:
-from google import genai
-client = genai.Client(api_key=self._api_key)
-response = await asyncio.to_thread(
-    client.models.generate_content,
-    model=self._model,
-    contents=prompt,
-)
-text = response.text
-```
+## Model IDs
 
-Different import, different client class, different method name, different response structure. This is why the `ReasoningProvider` abstraction exists — it hides these differences behind a common `generate_text()` method.
+The coding endpoint accepts multiple model aliases:
 
-If Gemini offered an OpenAI-compatible endpoint (some Google models do through Vertex AI), both providers could use the same OpenAI SDK with different base URLs. The abstraction would still be useful (different rate limit detection, different error shapes), but the client code would be nearly identical.
+| Model ID | What it is |
+|----------|-----------|
+| `kimi-for-coding` | Default; routes to the current coding-optimized model |
+| `kimi-for-coding/k2p5` | Coding-specific variant of K2.5 |
+| `kimi-k2.5` | General-purpose K2.5 (accepted on coding endpoint since Kimi unified their credit pool in April 2026) |
 
-## The `extract_json` utility
+The code uses `kimi-for-coding` as the default. All three currently work because Kimi unified billing across Kimi Code, Kimi Chat, Agent, and PPT — the coding endpoint will accept general models too.
 
-**File:** `backend/app/providers/utils.py`
+## Retry & rate-limit behavior
 
-Both providers use a shared utility to extract JSON from LLM responses. LLMs often wrap JSON in markdown code fences:
-
-````
-Here is the analysis:
-
-```json
-{"hook_type": "question", "pacing": "fast", ...}
-```
-
-I hope this helps!
-````
-
-`extract_json()` strips the wrapping and returns just the JSON string. This is a shared concern — all LLM providers have this problem, regardless of which API they use.
-
-## Retry and error handling
-
-Both KimiProvider and GeminiProvider implement the same retry pattern:
-
-```python
-BACKOFF_SECS = [1, 2, 4]
-MAX_RETRIES = 3
-
-for attempt in range(MAX_RETRIES):
-    try:
-        response = ...  # API call
-        # parse response...
-        return result
-    except Exception as e:
-        if is_rate_limit(e):
-            await asyncio.sleep(BACKOFF_SECS[attempt])
-            continue
-        raise ProviderError(str(e), provider=self.name)
-```
-
-**Exponential backoff:** 1s, 2s, 4s. Each retry waits longer. This is the standard pattern for handling rate limits — give the provider time to reset its counter.
-
-**Rate limit detection is provider-specific:**
-- Kimi: `"429" in str(e) or "rate" in str(e).lower()`
-- Gemini: `"429" in str(e) or "RESOURCE_EXHAUSTED" in str(e)`
-
-The error string matching is fragile (it depends on the exact error message format), but it works for known providers. A more robust approach would check `e.status_code == 429` directly.
-
-## Adding a new provider
-
-To add a hypothetical Claude provider:
-
-1. Create `backend/app/providers/claude.py`:
-```python
-class ClaudeProvider:
-    name = "claude"
-    async def generate_text(self, prompt, schema=None):
-        # Use Anthropic SDK
-        ...
-```
-
-2. Register it in `backend/app/providers/registry.py`:
-```python
-from app.providers.claude import ClaudeProvider
-_reasoning_providers["claude"] = ClaudeProvider
-```
-
-3. Add `claude_api_key` and `claude_rpm` to `backend/app/config.py`
-
-4. Add `"claude": settings.claude_api_key` to `_get_provider`'s `key_map` in `tasks.py`
-
-That's it. No stage functions change. No orchestrator changes. No SSE changes. No tests change (except adding provider-specific tests).
+Provider-level retries are covered in [Article 16](16-rate-limiting.md). Key detail: the provider separates retry budgets by error class. Transient parse/schema errors get a short 3-attempt budget (1s/2s/4s). Concurrency rate limits (429s) get their own patient 4-attempt budget (8s/20s/45s/90s with ±30% jitter). The two don't share a budget, so a rate-limited task doesn't exhaust its retries on fast backoffs before the limit clears.
 
 ## What you should take from this
 
-1. **OpenAI-compatible APIs are the industry standard.** If you're integrating with an LLM provider, check if they have an OpenAI-compatible endpoint. If they do, you can reuse the OpenAI SDK.
+1. **"X-compatible API" claims are promises with an expiration date.** OpenAI compatibility worked for Kimi until it didn't. Don't hardcode to the shape; hide it behind an interface.
 
-2. **`base_url` + `api_key` + `default_headers` are the three knobs.** That's all you need to point the OpenAI SDK at a different provider.
+2. **`base_url` + `default_headers` is a pattern, not an SDK feature.** Both OpenAI's and Anthropic's Python SDKs expose it. If you're using one, you can use the other. The migration was ~30 lines.
 
-3. **`asyncio.to_thread` is the bridge between sync and async.** When you have a synchronous SDK and an async application, wrap the call in `to_thread` to avoid blocking the event loop.
+3. **Endpoint policies (UA whitelist) survive SDK migrations.** When you switch clients, carry forward the policy workarounds or you'll be debugging a 403 for an hour.
 
-4. **Shared utilities (`extract_json`) reduce code duplication across providers.** Provider-specific code handles auth and error detection; shared code handles response parsing.
+4. **Provider code is churn-heavy; stage code shouldn't be.** Two migrations, zero changes to S1-S6. The interface pays for itself in rewrite-avoidance.
 
-5. **Every provider will need custom error detection.** HTTP 429 is standard, but the error message format varies. Encapsulate provider-specific error handling inside the provider class, not in the caller.
+5. **Document the history in the docstring.** The "legacy OpenAI shim returns a misleading error" comment in `kimi.py` is load-bearing. Six months from now, somebody will try the OpenAI route again and be confused — the comment tells them why not to.
 
 ---
 
-***Next: [Rate Limiting a Shared Upstream](16-rate-limiting.md) — the token bucket algorithm, centralized vs distributed rate limiting, and a documented race condition.***
+***Next: [Rate Limiting a Shared Upstream](16-rate-limiting.md) — the retry-budget-per-error-class pattern that keeps Flair2 alive under Kimi's concurrency throttling.***

--- a/docs/lessons/16-rate-limiting.md
+++ b/docs/lessons/16-rate-limiting.md
@@ -2,6 +2,8 @@
 
 > When multiple workers share one API key with a per-minute rate limit, you need centralized coordination. This article teaches the token bucket algorithm, its Redis implementation, and a documented race condition you should know about.
 
+> **Note (April 2026):** production has since moved from the token-bucket to a **Redis semaphore** because Kimi's real constraint turned out to be concurrent in-flight requests (≤30), not requests per minute. The token bucket lives on in the M5-1 backpressure experiment. Both mechanisms and the migration rationale are covered together below.
+
 ## The problem
 
 Kimi (and most LLM providers) enforce a per-minute rate limit — say, 60 requests per minute per API key. Flair2 has multiple workers, all using the same API key. If each worker independently tracks "how many calls have I made this minute," the total would exceed the limit because they can't see each other's counts.
@@ -182,6 +184,56 @@ The backpressure experiment (in `tests/experiments/test_backpressure.py`) tested
 Flair2 uses **fixed window** (counter + TTL), which has a known edge case: at the boundary between two windows, you could make `max_tokens` calls in the last second of window 1 and `max_tokens` calls in the first second of window 2 — double the intended rate in a 2-second burst. **Sliding window** fixes this by counting calls in a rolling time period, but it's more complex to implement in Redis.
 
 For Flair2's LLM calls (which take 2-5 seconds each), the boundary burst is impossible in practice — you can't make 60 calls in one second. The fixed window approximation is fine.
+
+## Production swap: semaphore replaces token bucket
+
+As Flair2 ran against real Kimi traffic, a pattern emerged: most 429s came not from exceeding a per-minute count but from exceeding **concurrent in-flight requests** (Kimi Code's cap is ~30). Rate/minute wasn't the right mental model.
+
+The fix, in `backend/app/infra/rate_limiter.py`, is a `RedisSemaphore` — a classic counting semaphore backed by an atomic Redis counter. Before each LLM call, the worker acquires a slot; after the call (or on exception), it releases. The semaphore size is set from `settings.kimi_max_concurrency = 29` (one headroom slot under Kimi's ceiling).
+
+```python
+@asynccontextmanager
+async def _acquire_provider_slot(redis, provider_name):
+    if not settings.enable_rate_limiter:
+        yield; return
+    max_slots = getattr(settings, f"{provider_name}_max_concurrency", None)
+    if not max_slots:
+        yield; return
+    sem = RedisSemaphore(redis, provider_name, max_slots=max_slots)
+    await sem.acquire()
+    try:
+        yield
+    finally:
+        await sem.release()
+```
+
+Each S1/S3/S4/S6 task wraps its LLM call in this context manager. The semaphore exposes actual concurrency, not a per-minute rate — which is what Kimi's endpoint actually cares about.
+
+**Why both still exist:** the token bucket is kept around because M5-1 (backpressure experiment) measures its fairness properties across K concurrent users. Production traffic goes through the semaphore. Two primitives, two purposes.
+
+## Retry budget per error class
+
+A second rate-limit improvement: when a 429 does get through (transient spikes happen), the provider retries it — but on a much longer schedule than regular errors.
+
+In `providers/kimi.py`:
+
+```python
+# Short backoff for transient parse/schema errors
+BACKOFF_SECS = [1, 2, 4]
+MAX_RETRIES = 3
+
+# Long backoff for 429s — Kimi's "too many concurrent" clears in 10-30s,
+# and jitter is critical when 100 tasks all hit the limit together.
+RATE_LIMIT_BACKOFF = [8, 20, 45, 90]
+RATE_LIMIT_JITTER_FRAC = 0.3
+RATE_LIMIT_MAX_RETRIES = len(RATE_LIMIT_BACKOFF)
+```
+
+Parse/schema errors and rate-limit errors have **separate retry budgets**. A task hitting repeated 429s doesn't burn its 3-attempt budget in 7 seconds — it gets 4 patient attempts totaling ~165 seconds plus jitter. If it still fails, `RateLimitError` is raised with `retry_after` set, and the Celery task wrapper uses that as its own retry countdown (with another ±25% jitter layer on top).
+
+**Total patience for a persistent 429:** ~165s at the provider, then up to 5 Celery retries at ~90s each. Roughly 10 minutes before giving up — enough time for almost any real concurrency throttling to clear.
+
+**The pattern:** don't mix fast and slow retries in the same budget. Transient noise deserves aggressive quick retries. Upstream throttling deserves patience. One budget can't satisfy both.
 
 ## What you should take from this
 

--- a/docs/presentation/index.html
+++ b/docs/presentation/index.html
@@ -1,0 +1,686 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Flair2 — Distributed AI Campaign Studio</title>
+<style>
+  :root {
+    --bg: #f7f5ef;
+    --surface: #ffffff;
+    --ink: #1a1a1a;
+    --ink-muted: #6b6b6b;
+    --ink-light: #9b9b9b;
+    --border: #e3dfd4;
+    --disc: #3b82f6;
+    --stud: #f59e0b;
+    --eval: #14b8a6;
+    --pers: #a855f7;
+    --success: #22c55e;
+    --error: #ef4444;
+    --warning: #f59e0b;
+    --mono: "SF Mono", "Monaco", "Cascadia Code", Menlo, monospace;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif; font-size: 14px; line-height: 1.55; }
+
+  /* ── Top navigation bar ────────────────────────────────── */
+  .topnav {
+    position: sticky; top: 0; z-index: 100;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 10px 20px;
+  }
+  .topnav-row {
+    display: flex; align-items: center; gap: 16px;
+    max-width: 1400px; margin: 0 auto;
+  }
+  .logo {
+    font-family: var(--mono); font-size: 13px; font-weight: 700;
+    letter-spacing: 0.04em; color: var(--ink);
+    border: 1.5px solid var(--ink); padding: 3px 8px; border-radius: 3px;
+  }
+  .tabs { display: flex; gap: 4px; flex-wrap: wrap; }
+  .tab {
+    font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
+    padding: 6px 10px; border-radius: 3px; cursor: pointer;
+    color: var(--ink-muted);
+    background: transparent; border: 1px solid transparent;
+    transition: all 0.15s;
+    font-weight: 500;
+  }
+  .tab:hover { background: var(--bg); color: var(--ink); }
+  .tab.active { background: var(--ink); color: var(--surface); }
+  .tab-num { font-family: var(--mono); font-size: 10px; opacity: 0.6; margin-right: 4px; }
+
+  /* ── System status strip ───────────────────────────────── */
+  .status-strip {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 8px 20px;
+    font-family: var(--mono); font-size: 11px;
+  }
+  .status-row { display: flex; gap: 20px; flex-wrap: wrap; max-width: 1400px; margin: 0 auto; align-items: center; color: var(--ink-muted); }
+  .status-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+  .ok { background: var(--success); }
+  .warn { background: var(--warning); }
+  .err { background: var(--error); }
+  .status-label { color: var(--ink); font-weight: 500; }
+  .status-sep { color: var(--ink-light); }
+
+  /* ── Sections ──────────────────────────────────────────── */
+  .section {
+    max-width: 1400px; margin: 0 auto;
+    padding: 32px 24px 48px;
+    display: none;
+    animation: fadeIn 0.2s ease;
+  }
+  .section.active { display: block; }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  h1 { font-size: 28px; font-weight: 700; letter-spacing: -0.01em; margin: 0 0 6px; }
+  h2 { font-size: 17px; font-weight: 600; letter-spacing: 0.01em; margin: 28px 0 10px; color: var(--ink); }
+  h3 { font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-muted); margin: 20px 0 8px; }
+  .kicker { font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--ink-light); margin-bottom: 4px; }
+  .lead { font-size: 15px; color: var(--ink-muted); margin-bottom: 24px; }
+
+  p { margin: 0 0 12px; }
+
+  code { font-family: var(--mono); font-size: 12px; background: var(--surface); padding: 1px 5px; border: 1px solid var(--border); border-radius: 3px; }
+  pre { font-family: var(--mono); font-size: 12px; background: var(--surface); padding: 12px 16px; border: 1px solid var(--border); border-radius: 4px; overflow-x: auto; line-height: 1.5; margin: 10px 0; }
+  pre code { background: none; border: none; padding: 0; }
+  .comment { color: var(--ink-light); font-style: italic; }
+  .kw { color: var(--disc); }
+
+  ul { padding-left: 20px; margin: 0 0 12px; }
+  ul li { margin-bottom: 4px; }
+
+  /* ── Cards / grid layouts ──────────────────────────────── */
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 12px 0; }
+  .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin: 12px 0; }
+  @media (max-width: 900px) {
+    .grid-2, .grid-3 { grid-template-columns: 1fr; }
+  }
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 14px 16px;
+  }
+  .card h4 { font-size: 12px; font-weight: 700; letter-spacing: 0.04em; margin: 0 0 6px; text-transform: uppercase; }
+  .card p { font-size: 13px; color: var(--ink-muted); margin: 0; }
+
+  /* Color variants for cards */
+  .card.disc { border-left: 3px solid var(--disc); }
+  .card.stud { border-left: 3px solid var(--stud); }
+  .card.eval { border-left: 3px solid var(--eval); }
+  .card.pers { border-left: 3px solid var(--pers); }
+  .card.success { border-left: 3px solid var(--success); }
+  .card.warn { border-left: 3px solid var(--warning); }
+  .card.err { border-left: 3px solid var(--error); }
+
+  /* ── Stage pipeline diagram ────────────────────────────── */
+  .pipeline {
+    display: flex; gap: 6px; align-items: stretch;
+    margin: 16px 0; flex-wrap: wrap;
+  }
+  .stage-box {
+    flex: 1; min-width: 110px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 10px 12px;
+    font-size: 11px;
+    position: relative;
+  }
+  .stage-box.s1, .stage-box.s2 { border-top: 3px solid var(--disc); }
+  .stage-box.s3 { border-top: 3px solid var(--stud); }
+  .stage-box.s4, .stage-box.s5 { border-top: 3px solid var(--eval); }
+  .stage-box.s6 { border-top: 3px solid var(--pers); }
+  .stage-box .num { font-family: var(--mono); font-size: 10px; color: var(--ink-light); }
+  .stage-box .name { font-weight: 600; font-size: 13px; margin: 2px 0 4px; }
+  .stage-box .desc { color: var(--ink-muted); font-size: 11px; }
+  .stage-box .meta { font-family: var(--mono); font-size: 10px; color: var(--ink-light); margin-top: 4px; }
+
+  /* ── Tables ────────────────────────────────────────────── */
+  table { width: 100%; border-collapse: collapse; margin: 10px 0; font-size: 12.5px; }
+  th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border); }
+  th { font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-muted); }
+  td.mono { font-family: var(--mono); font-size: 11px; }
+  td.num { font-family: var(--mono); text-align: right; }
+
+  /* ── ASCII art / diagrams ──────────────────────────────── */
+  .ascii {
+    font-family: var(--mono); font-size: 10.5px; line-height: 1.35;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 4px;
+    padding: 14px; white-space: pre; overflow-x: auto;
+    margin: 10px 0;
+  }
+
+  /* ── Callouts ──────────────────────────────────────────── */
+  .callout {
+    border-left: 3px solid var(--ink);
+    background: var(--surface);
+    padding: 10px 14px;
+    margin: 12px 0;
+    font-size: 13px;
+  }
+  .callout.info { border-color: var(--disc); }
+  .callout.good { border-color: var(--success); }
+  .callout.warn { border-color: var(--warning); }
+  .callout strong { color: var(--ink); }
+
+  /* ── Metrics ───────────────────────────────────────────── */
+  .metric {
+    display: inline-block;
+    padding: 8px 12px;
+    margin: 0 8px 8px 0;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    min-width: 90px;
+  }
+  .metric .val { font-family: var(--mono); font-size: 18px; font-weight: 700; line-height: 1; color: var(--ink); }
+  .metric .lbl { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-muted); margin-top: 2px; }
+
+  /* ── Footer hint ───────────────────────────────────────── */
+  .kbd-hint {
+    position: fixed; bottom: 12px; right: 16px;
+    font-family: var(--mono); font-size: 10px;
+    color: var(--ink-light);
+    background: var(--surface);
+    padding: 4px 8px; border: 1px solid var(--border); border-radius: 3px;
+    z-index: 50; opacity: 0.75;
+  }
+  kbd {
+    display: inline-block;
+    padding: 0 4px;
+    font-family: var(--mono);
+    font-size: 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    color: var(--ink);
+  }
+</style>
+</head>
+<body>
+
+<!-- ── Top Navigation (always visible) ─────────────────── -->
+<nav class="topnav">
+  <div class="topnav-row">
+    <span class="logo">FLAIR</span>
+    <div class="tabs">
+      <button class="tab active" data-section="1"><span class="tab-num">1</span>Problem</button>
+      <button class="tab" data-section="2"><span class="tab-num">2</span>Architecture</button>
+      <button class="tab" data-section="3"><span class="tab-num">3</span>Pipeline</button>
+      <button class="tab" data-section="4"><span class="tab-num">4</span>Redis + MapReduce</button>
+      <button class="tab" data-section="5"><span class="tab-num">5</span>Kimi</button>
+      <button class="tab" data-section="6"><span class="tab-num">6</span>Experiments</button>
+      <button class="tab" data-section="7"><span class="tab-num">7</span>Lessons</button>
+    </div>
+  </div>
+</nav>
+
+<!-- ── System Status Strip ─────────────────────────────── -->
+<div class="status-strip">
+  <div class="status-row">
+    <span><span class="status-dot ok"></span><span class="status-label">ALB</span> flair2-dev-alb</span>
+    <span class="status-sep">·</span>
+    <span><span class="status-dot ok"></span><span class="status-label">ECS</span> API 2/2 healthy · Worker 2/2 healthy</span>
+    <span class="status-sep">·</span>
+    <span><span class="status-dot ok"></span><span class="status-label">ElastiCache</span> cache.t3.micro</span>
+    <span class="status-sep">·</span>
+    <span><span class="status-dot ok"></span><span class="status-label">Kimi</span> Allegretto · K2.6-code-preview</span>
+    <span class="status-sep">·</span>
+    <span style="color: var(--ink-light)">us-west-2 · account 314727362981 · main @ latest</span>
+  </div>
+</div>
+
+<!-- ─────────────────────────────────────────────────────────
+     SECTION 1 — PROBLEM & DESIGN FORCES
+───────────────────────────────────────────────────────── -->
+<section class="section active" id="s1">
+  <div class="kicker">01 · Problem</div>
+  <h1>Flair2 — AI Campaign Studio</h1>
+  <p class="lead">Generate social media marketing campaigns from viral video analysis. One user click triggers ~260 LLM calls and live streams the work. This shape forces a distributed system.</p>
+
+  <div class="grid-2">
+    <div>
+      <h2>What the user sees</h2>
+      <p>Enter a creator profile. Watch a 6-stage AI pipeline analyze 100 viral TikTok videos, generate candidate scripts, simulate 42 personas voting, and personalize the winners to the creator's voice. All in real time.</p>
+      <div class="metric"><div class="val">260</div><div class="lbl">LLM calls / run</div></div>
+      <div class="metric"><div class="val">~15s</div><div class="lbl">typical runtime</div></div>
+      <div class="metric"><div class="val">100</div><div class="lbl">real TikTok inputs</div></div>
+      <div class="metric"><div class="val">42</div><div class="lbl">predefined personas</div></div>
+    </div>
+    <div>
+      <h2>Three design forces</h2>
+      <ul>
+        <li><strong>Work is slow.</strong> 260 calls × 2–5s each = minutes, not milliseconds. Can't hold an HTTP request open that long.</li>
+        <li><strong>User needs live progress.</strong> A 15-second spinner is unacceptable. Must push events as each stage completes.</li>
+        <li><strong>Work fans out per request.</strong> S1 analyzes N videos concurrently. S4 has M personas voting concurrently. Need MapReduce coordination inside a single request.</li>
+      </ul>
+      <div class="callout info">
+        Every architectural decision that follows is a response to one of these three forces. No force → no need for the pattern.
+      </div>
+    </div>
+  </div>
+
+  <h2>V1 (hackathon) → V2 (engineered)</h2>
+  <table>
+    <thead><tr><th>V1</th><th>V2</th><th>Why it changed</th></tr></thead>
+    <tbody>
+      <tr><td class="mono">monolithic main.py</td><td class="mono">modular (api/pipeline/workers)</td><td>Module boundaries = change boundaries</td></tr>
+      <tr><td class="mono">in-memory state</td><td class="mono">Redis + Celery</td><td>Process death = state death</td></tr>
+      <tr><td class="mono">sequential pipeline</td><td class="mono">MapReduce fan-out</td><td>Sequential 260 calls ≈ 15 min. Concurrent ≈ 15s.</td></tr>
+      <tr><td class="mono">Gemini only</td><td class="mono">pluggable provider registry</td><td>Migrated Gemini → Kimi in one PR</td></tr>
+      <tr><td class="mono">no tests, no CI</td><td class="mono">111 tests + GitHub Actions</td><td>Locally-works, prod-breaks ended</td></tr>
+      <tr><td class="mono">Google Cloud Run</td><td class="mono">AWS ECS + ElastiCache + ALB</td><td>Richer distributed-systems story</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────
+     SECTION 2 — ARCHITECTURE
+───────────────────────────────────────────────────────── -->
+<section class="section" id="s2">
+  <div class="kicker">02 · Architecture</div>
+  <h1>Three Layers of Distribution</h1>
+  <p class="lead">Each layer solves a different problem. Understanding which layer is hurting is half of operating the system.</p>
+
+  <div class="ascii">                          Internet
+                             │
+                         ┌───┴───┐
+                         │  ALB  │  (Application Load Balancer)
+                         └───┬───┘
+                             │
+                    ┌────────┼────────┐
+              ┌─────┴─────┐   ┌──────┴──────┐
+              │  API Task │   │  API Task   │  FastAPI · ECS Fargate (2-6)
+              │  (FastAPI)│   │  (FastAPI)  │  autoscale @ CPU > 60%
+              └─────┬─────┘   └─────┬───────┘
+                    └────────┬──────┘
+                             │
+                    ┌────────┴────────┐
+                    │   ElastiCache   │  Redis cache.t3.micro
+                    │   (Redis 7)     │  queue · state · stream · cache · limiter
+                    └────────┬────────┘
+                             │
+                    ┌────────┼────────┐
+              ┌─────┴──────┐ ┌───────┴─────┐
+              │  Worker    │ │  Worker     │  Celery · ECS Fargate (2-4)
+              │  (Celery)  │ │  (Celery)   │  concurrency=4 per task
+              └─────┬──────┘ └─────┬───────┘
+                    └────────┬─────┘
+                             │
+                    ┌────────┴────────┐
+                    │    Kimi API     │  Anthropic Messages API
+                    │ (Moonshot AI)   │  k2.5 · semaphore-capped at 29
+                    └─────────────────┘
+
+
+  Frontend:   Astro + React islands (static build) → S3 website hosting
+  Terraform:  ~50 AWS resources, all managed, state in S3 bucket</div>
+
+  <div class="grid-3">
+    <div class="card disc">
+      <h4>Layer 1 — Edge ↔ API</h4>
+      <p>Browser talks to ALB over HTTPS. ALB distributes to healthy API tasks. Solves availability + load balancing.</p>
+    </div>
+    <div class="card stud">
+      <h4>Layer 2 — API ↔ Workers</h4>
+      <p>API enqueues to Redis, returns in milliseconds. Workers pull tasks and run them elsewhere. Solves long-running work.</p>
+    </div>
+    <div class="card eval">
+      <h4>Layer 3 — Worker ↔ Worker</h4>
+      <p>Multiple workers process tasks for one run concurrently. Coordinate via atomic Redis counters + SETNX transition guards. Solves MapReduce inside one request.</p>
+    </div>
+  </div>
+
+  <h2>Redis — five hats on one server</h2>
+  <table>
+    <thead><tr><th>Role</th><th>Redis feature</th><th>Key pattern</th><th>DB</th></tr></thead>
+    <tbody>
+      <tr><td>Celery broker</td><td class="mono">LPUSH / BLPOP</td><td class="mono">celery</td><td class="mono">db=1</td></tr>
+      <tr><td>Pipeline state</td><td class="mono">SET / GET</td><td class="mono">run:{id}:*</td><td class="mono">db=0</td></tr>
+      <tr><td>SSE event stream</td><td class="mono">XADD / XREAD</td><td class="mono">sse:{id}</td><td class="mono">db=0</td></tr>
+      <tr><td>Concurrency semaphore</td><td class="mono">atomic counter</td><td class="mono">semaphore:{provider}</td><td class="mono">db=0</td></tr>
+      <tr><td>Idempotency cache</td><td class="mono">SETNX</td><td class="mono">s1_result:*, etc.</td><td class="mono">db=0</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout warn">
+    <strong>Clever and dangerous.</strong> One Redis instance wearing five hats simplifies ops but creates a single point of failure. At production scale, broker and stream would split onto dedicated instances.
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────
+     SECTION 3 — PIPELINE
+───────────────────────────────────────────────────────── -->
+<section class="section" id="s3">
+  <div class="kicker">03 · Pipeline</div>
+  <h1>Six Stages, Two MapReduce Cycles</h1>
+  <p class="lead">S1/S4 fan out (map). S2/S5 aggregate (reduce). S3 generates scripts sequentially. S6 personalizes top results.</p>
+
+  <div class="pipeline">
+    <div class="stage-box s1">
+      <div class="num">S1</div>
+      <div class="name">Discover</div>
+      <div class="desc">Analyze each video. Extract hook, pacing, retention mechanics.</div>
+      <div class="meta">MAP · 100 LLM calls · concurrent</div>
+    </div>
+    <div class="stage-box s2">
+      <div class="num">S2</div>
+      <div class="name">Aggregate</div>
+      <div class="desc">Group patterns by hook+pacing. Rank by frequency.</div>
+      <div class="meta">REDUCE · 0 LLM calls · Python only</div>
+    </div>
+    <div class="stage-box s3">
+      <div class="num">S3</div>
+      <div class="name">Generate</div>
+      <div class="desc">Write candidate scripts, one per pattern, on creator's niche.</div>
+      <div class="meta">SEQUENTIAL · 20 LLM calls</div>
+    </div>
+    <div class="stage-box s4">
+      <div class="num">S4</div>
+      <div class="name">Vote</div>
+      <div class="desc">42 personas each pick top-5 scripts.</div>
+      <div class="meta">MAP · 42 LLM calls · concurrent</div>
+    </div>
+    <div class="stage-box s5">
+      <div class="num">S5</div>
+      <div class="name">Rank</div>
+      <div class="desc">Weighted Borda count (rank-1 = 5pt … rank-5 = 1pt).</div>
+      <div class="meta">REDUCE · 0 LLM calls · Python only</div>
+    </div>
+    <div class="stage-box s6">
+      <div class="num">S6</div>
+      <div class="name">Personalize</div>
+      <div class="desc">Rewrite top-N scripts in creator's voice. Generate video prompts.</div>
+      <div class="meta">MAP · 10 LLM calls · concurrent</div>
+    </div>
+  </div>
+
+  <div class="grid-2">
+    <div>
+      <h2>Creator profile shapes S3 + S6</h2>
+      <p>The creator's <strong>niche</strong>, <strong>content themes</strong>, and <strong>recent topics</strong> are injected into S3's prompt, so scripts come out on-topic. S6 then personalizes the winners with the creator's <strong>tone</strong>, <strong>vocabulary</strong>, and <strong>catchphrases</strong>.</p>
+      <p>Before this fix: Kitchen Confident got productivity scripts in cooking vocabulary. After: actual on-topic cooking content.</p>
+    </div>
+    <div>
+      <h2>Resilience baked in</h2>
+      <ul>
+        <li><strong>Skip-and-continue:</strong> one un-analyzable video doesn't kill the run — it's marked skipped and S2 aggregates the rest.</li>
+        <li><strong>95% completion threshold:</strong> stragglers don't block transitions. S1→S2 fires when 95 of 100 complete. SETNX guards exactly-once dispatch.</li>
+        <li><strong>S4 checkpointing:</strong> every vote writes a checkpoint. Crash mid-S4 resumes from there — saves 30-73% of LLM calls.</li>
+        <li><strong>Silent failure is not allowed:</strong> if workers stall for 30s, frontend probes the API and tells the user specifically why.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="callout info">
+    <strong>Total shape:</strong> 260 LLM calls → 15 seconds on 20-way concurrency. Limited by Kimi's concurrency ceiling, not our CPU or network. The semaphore + retry-budget-per-error-class (next section) keeps us inside that ceiling.
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────
+     SECTION 4 — REDIS + MAPREDUCE
+───────────────────────────────────────────────────────── -->
+<section class="section" id="s4">
+  <div class="kicker">04 · Coordination</div>
+  <h1>Redis as the Nervous System</h1>
+  <p class="lead">Every coordination primitive goes through Redis. Single-writer orchestrator + atomic counters + SETNX guards = MapReduce without locks.</p>
+
+  <div class="grid-2">
+    <div>
+      <h2>The counter pattern (distributed barrier)</h2>
+<pre><code><span class="comment"># When an S1 task completes:</span>
+done = await redis.incr(f"run:{id}:s1:done")
+
+<span class="comment"># Check if threshold crossed:</span>
+needed = math.ceil(num_videos * 0.95)
+if done &gt;= needed:
+    <span class="comment"># SETNX ensures exactly-once transition</span>
+    if await redis.setnx(f"run:{id}:s2:triggered", "1"):
+        s2_aggregate_task.delay(run_id)</code></pre>
+      <p><code>INCR</code> is atomic — 100 concurrent workers never collide. SETNX ensures only one of them fires the transition.</p>
+    </div>
+    <div>
+      <h2>The semaphore (concurrency limit)</h2>
+<pre><code><span class="comment"># Before every Kimi call:</span>
+async with _acquire_provider_slot(redis, "kimi"):
+    pattern = await s1_analyze(video, provider)
+<span class="comment"># Auto-releases on exit</span>
+
+<span class="comment"># max_slots=29 — Kimi's ceiling is 30, we leave one slot</span>
+<span class="comment"># of headroom to avoid racing with the limit</span></code></pre>
+      <p>Any number of Celery workers can pull tasks. The semaphore caps in-flight LLM calls so we never trigger Kimi's concurrency throttle.</p>
+    </div>
+  </div>
+
+  <h2>Single-writer orchestrator</h2>
+  <p>Every state write and every SSE event goes through one code path — the <code>Orchestrator</code>. Workers report completions via callbacks (<code>on_s1_complete</code>, <code>on_s4_complete</code>); only the orchestrator mutates <code>run:{id}:*</code> keys or appends to the SSE stream. No locks, no races.</p>
+
+  <div class="callout good">
+    <strong>Same principle as:</strong> Raft leaders, event sourcing, database write-ahead logs, Node.js event loops. Mutation through one writer &gt; mutation through many writers with coordination.
+  </div>
+
+  <h2>SSE via Redis Streams (not pub/sub)</h2>
+  <p>Streams persist, support cursors, and handle replay. A browser that reconnects mid-run sends <code>Last-Event-ID</code>; the server resumes from exactly that cursor. Late-joining tabs replay from the beginning. Multi-tab safe with no extra work.</p>
+<pre><code><span class="comment"># SSE manager — blocks 5s for new events, then re-checks for disconnect</span>
+entries = await redis.xread({f"sse:{id}": last_id}, block=5000)
+for entry_id, fields in entries:
+    yield ServerSentEvent(id=entry_id, event=fields["event"], data=fields["data"])
+    last_id = entry_id</code></pre>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────
+     SECTION 5 — KIMI
+───────────────────────────────────────────────────────── -->
+<section class="section" id="s5">
+  <div class="kicker">05 · Kimi Integration</div>
+  <h1>Two SDK Migrations, Zero Stage Changes</h1>
+  <p class="lead">The provider abstraction paid for itself twice. When the LLM backend changed — both the provider AND the SDK — no pipeline code moved.</p>
+
+  <div class="grid-2">
+    <div>
+      <h2>Migration 1 — Gemini → Kimi</h2>
+      <p>Gemini had intermittent 500s and tight rate limits. Kimi Code offered better availability on a subscription plan. <strong>PR #95</strong>: one-line change in the registry, Terraform secret swap. Zero stage code touched.</p>
+    </div>
+    <div>
+      <h2>Migration 2 — OpenAI SDK → Anthropic SDK</h2>
+      <p>Kimi's OpenAI-compatible route went dead — started returning a misleading "temperature" error. The real surface moved to an Anthropic Messages API shape at <code>/coding/v1/messages</code>. Rewrote just the <code>KimiProvider</code> to use <code>AsyncAnthropic</code>. Zero stage code touched again.</p>
+    </div>
+  </div>
+
+  <h2>Retry budget per error class</h2>
+  <p>Most 429s aren't quota exhaustion — they're transient concurrency throttling that clears in 10–30 seconds. A fast retry budget (1s/2s/4s total 7s) is too impatient. A slow budget is wrong for parse errors. So we split them:</p>
+
+  <div class="grid-2">
+    <div class="card warn">
+      <h4>Fast budget — schema/parse errors</h4>
+      <p style="font-family: var(--mono); font-size: 11px;">3 attempts · 1s / 2s / 4s</p>
+      <p>Transient noise. Retry aggressively. Total ~7s.</p>
+    </div>
+    <div class="card err">
+      <h4>Slow budget — 429 rate limits</h4>
+      <p style="font-family: var(--mono); font-size: 11px;">4 attempts · 8s / 20s / 45s / 90s + ±30% jitter</p>
+      <p>Real throttling. Be patient. Total ~165s at provider + ~5 Celery retries = ~10 min of patience.</p>
+    </div>
+  </div>
+
+  <div class="callout info">
+    <strong>Jitter prevents thundering herd.</strong> When 42 S4 voters all hit the rate limit within milliseconds and all retry on the same backoff schedule, they all get throttled again. ±30% jitter desynchronizes them.
+  </div>
+
+  <h2>The User-Agent whitelist</h2>
+  <p>Kimi's coding endpoint is gated by User-Agent — only approved clients (Kimi CLI, Claude Code, Roo Code) can use it. We spoof <code>User-Agent: claude-code/0.1.0</code> via <code>default_headers</code>. This is fragile — Kimi could tighten validation at any time — but it's the documented way the ecosystem uses it.</p>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────
+     SECTION 6 — EXPERIMENTS
+───────────────────────────────────────────────────────── -->
+<section class="section" id="s6">
+  <div class="kicker">06 · Experiments</div>
+  <h1>Distributed Systems, Empirically</h1>
+  <p class="lead">Seven experiments across four questions. Measuring what the design claims to buy.</p>
+
+  <h2>M5 — Pipeline resilience (fakeredis, local)</h2>
+  <div class="grid-3">
+    <div class="card disc">
+      <h4>M5-1 · Backpressure</h4>
+      <p>Does the rate limiter prevent API storms under K concurrent users?</p>
+      <p style="margin-top:6px;"><strong>Result:</strong> without limiter, 90% error rate at K=10. With limiter: 0%.</p>
+    </div>
+    <div class="card stud">
+      <h4>M5-2 · Failure recovery</h4>
+      <p>When a worker crashes mid-S4, how much work does the checkpoint save?</p>
+      <p style="margin-top:6px;"><strong>Result:</strong> 30–73% of LLM calls saved depending on crash timing. Sibling runs unaffected.</p>
+    </div>
+    <div class="card eval">
+      <h4>M5-3 · Cache concurrency</h4>
+      <p>Does SETNX caching prevent redundant LLM calls under K concurrent users?</p>
+      <p style="margin-top:6px;"><strong>Result:</strong> LLM call count fixed at NUM_VIDEOS regardless of K. 99% savings at K=100.</p>
+    </div>
+  </div>
+
+  <h2>M5-4 — API load test (Locust against AWS)</h2>
+  <table>
+    <thead><tr><th>K users</th><th>p50</th><th>p95</th><th>p99</th><th>RPS</th><th>Failures</th></tr></thead>
+    <tbody>
+      <tr><td>10</td><td class="num">35 ms</td><td class="num">51 ms</td><td class="num">190 ms</td><td class="num">4.8</td><td class="num">0</td></tr>
+      <tr><td>50</td><td class="num">35 ms</td><td class="num">59 ms</td><td class="num">100 ms</td><td class="num">48</td><td class="num">0</td></tr>
+      <tr><td>100</td><td class="num">34 ms</td><td class="num">61 ms</td><td class="num">140 ms</td><td class="num">48</td><td class="num">0</td></tr>
+      <tr><td>500 sustained</td><td class="num">77 ms</td><td class="num">12 000 ms</td><td class="num">18 000 ms</td><td class="num">130</td><td class="num">18</td></tr>
+    </tbody>
+  </table>
+  <p style="font-size:12px; color:var(--ink-muted);"><em>Placeholder: Jess is re-running with latest code; numbers to be updated.</em></p>
+
+  <h2>M6 — ElastiCache under real concurrency</h2>
+  <div class="grid-3">
+    <div class="card eval">
+      <h4>M6-1 · Latency</h4>
+      <p>SETNX p50: 0.4ms, p99 &lt;2ms. ~10× slower than fakeredis but well within SLA.</p>
+    </div>
+    <div class="card eval">
+      <h4>M6-2 · SETNX atomicity</h4>
+      <p>Exactly 1 winner at K=10–1000. Fails at K=5000 due to client connection pool exhaustion — not a Redis fault.</p>
+    </div>
+    <div class="card eval">
+      <h4>M6-3 · Memory pressure</h4>
+      <p>Peak usage stays well under cache.t3.micro limit across all tested scales.</p>
+    </div>
+  </div>
+
+  <h2>Cross-experiment findings</h2>
+  <ol>
+    <li><strong>Redis connection pool is the system-wide bottleneck at scale.</strong> Both M5-4 (API p99 = 18s at K=500) and M6-2 (SETNX fails at K=5000) point to the same root cause — connection pool exhaustion. Fix is pool sizing, not instance scaling.</li>
+    <li><strong>CPU is the wrong auto-scaling metric for Workers.</strong> Worker CPU peaked at 7.14% under the heaviest load. Workers are IO-bound on LLM calls. The correct signal is Celery queue depth.</li>
+    <li><strong>fakeredis hides real failure modes.</strong> M5-3 passed at K=100,000 in fakeredis. M6-2 failed at K=5,000 on ElastiCache. Connection pools are invisible in the simulator.</li>
+    <li><strong>Auto-scaling works but needs the right metric.</strong> ECS correctly detected CPU overload and added tasks. But CPU wasn't the bottleneck.</li>
+  </ol>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────
+     SECTION 7 — LESSONS
+───────────────────────────────────────────────────────── -->
+<section class="section" id="s7">
+  <div class="kicker">07 · Lessons</div>
+  <h1>Things That Broke and What They Taught</h1>
+  <p class="lead">Every incident left a fingerprint. Here are the ones worth carrying forward.</p>
+
+  <div class="grid-2">
+    <div>
+      <h2>Process lessons</h2>
+      <ul>
+        <li><strong>Hard branch protection works.</strong> GitHub ruleset physically blocked direct pushes and required a reviewer. 112 merged PRs, all reviewed. Neither of us could ship without the other reading the diff.</li>
+        <li><strong>Interface contract (issue #71) up front.</strong> Every Redis key, every SSE event, every API route specified before anyone wrote the corresponding code. Let Sam and Jess work in parallel for weeks and integrate cleanly.</li>
+        <li><strong>Conventional commits.</strong> <code>feat:</code> / <code>fix:</code> / <code>chore:</code> / <code>docs:</code>. Makes git history greppable. "What did we change about Celery?" is a one-line search.</li>
+        <li><strong>Test failure paths explicitly.</strong> M5-2 validated checkpoint recovery <em>before</em> any real crash. The first production crash saved 50% of LLM calls on the first try.</li>
+      </ul>
+    </div>
+    <div>
+      <h2>Technical lessons</h2>
+      <ul>
+        <li><strong>"X-compatible API" claims expire.</strong> Kimi's OpenAI-compatible shim went dead. The abstraction let us migrate to Anthropic's SDK in ~30 lines.</li>
+        <li><strong>Connection pools are invisible bottlenecks.</strong> Tail latency spikes with nothing obviously saturated = bounded resource exhaustion. Instrument pools explicitly.</li>
+        <li><strong>Retry budget per error class.</strong> Transient noise needs fast retries. Upstream throttling needs patience. One budget can't satisfy both.</li>
+        <li><strong>Single-writer discipline beats locks.</strong> The orchestrator is the only code path that mutates run state. No races, no locks, no bugs.</li>
+        <li><strong>Don't fake progress.</strong> If workers stalled, show the user specifically why — don't let the UI simulate activity that isn't happening.</li>
+        <li><strong>Skip-and-continue &gt; fail-the-run.</strong> At N=100 the probability of at least one bad input approaches 1. Design for partial failure from day one.</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>Ten production incidents, condensed</h2>
+  <table>
+    <thead><tr><th>#</th><th>Symptom</th><th>Root cause</th><th>Fix</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td>Gemini 500s + rate limits</td><td>Provider instability</td><td>Switch to Kimi (registry paid off)</td></tr>
+      <tr><td>2</td><td>S1 always 500s in prod</td><td><code>.dockerignore</code> excluded <code>data/</code></td><td>4 PRs to fully root-cause</td></tr>
+      <tr><td>3</td><td>All Kimi requests return misleading "temperature" error</td><td>OpenAI shim deprecated</td><td>Migrate to Anthropic Messages API</td></tr>
+      <tr><td>4</td><td>Workers deployed, pipeline silently hangs</td><td>Celery never imported task module</td><td>One-line fix in <code>celery_app.py</code></td></tr>
+      <tr><td>5</td><td>Frontend faked progress when backend stalled</td><td>Stage events don't mean stage is working</td><td>Single-writer events + 30s stall detector + API probe</td></tr>
+      <tr><td>6</td><td>"ELB already exists" on every deploy</td><td>Terraform state drift</td><td>Idempotent import workflow (~50 resources)</td></tr>
+      <tr><td>7</td><td>S4 fails at persona 40 with 429</td><td>Concurrency throttle + impatient retry</td><td>Semaphore cap + retry budget per error class</td></tr>
+      <tr><td>8</td><td>One bad video kills whole S1 run</td><td>Schema-strict validation</td><td>Skip-and-continue + 95% threshold</td></tr>
+      <tr><td>9</td><td>Pipeline hangs at 99/100</td><td>10-min retry for one straggler</td><td>ceil(N × 0.95) threshold with SETNX guard</td></tr>
+      <tr><td>10</td><td>"Start Pipeline" bounces to home page</td><td>S3 website serves ROOT index.html on 404</td><td>Query-param routing (<code>?id=...</code>)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>The bigger picture</h2>
+  <div class="callout info">
+    <strong>The system works because of the abstractions, not despite them.</strong> Every "premature abstraction" in this repo paid for itself. Provider registry paid off twice. Single-writer orchestrator eliminated whole classes of race conditions. Interface contract let two people work independently. When abstractions match the domain's natural joints, they're not overhead — they're the only thing that makes change affordable.
+  </div>
+</section>
+
+<div class="kbd-hint">
+  <kbd>1</kbd>–<kbd>7</kbd> jump · <kbd>←</kbd> <kbd>→</kbd> prev/next
+</div>
+
+<script>
+  const sections = document.querySelectorAll('.section');
+  const tabs = document.querySelectorAll('.tab');
+
+  function show(n) {
+    sections.forEach(s => s.classList.remove('active'));
+    tabs.forEach(t => t.classList.remove('active'));
+    document.getElementById('s' + n).classList.add('active');
+    document.querySelector(`.tab[data-section="${n}"]`).classList.add('active');
+    history.replaceState(null, '', '#s' + n);
+    window.scrollTo(0, 0);
+  }
+
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => show(tab.dataset.section));
+  });
+
+  // Keyboard: 1-7 for direct jump, arrows for prev/next
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    const current = Array.from(sections).findIndex(s => s.classList.contains('active')) + 1;
+    if (e.key >= '1' && e.key <= '7') {
+      show(e.key);
+    } else if (e.key === 'ArrowRight' && current < 7) {
+      show(current + 1);
+    } else if (e.key === 'ArrowLeft' && current > 1) {
+      show(current - 1);
+    }
+  });
+
+  // Deep link on load
+  const hash = window.location.hash;
+  if (hash.match(/^#s[1-7]$/)) {
+    show(hash.slice(2));
+  }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Problem
Previous personas read like content creators / viral-video enthusiasts ("Luna treats TikTok as her choreography notebook", "Jasmine collects Vietnamese-market equivalents of viral ingredients"). But S4 is supposed to simulate the audience whose thumb decides if a script works — not a panel of amateur producers.

## Fix
Regenerated all 42 personas with a prompt that explicitly bans creator framings and grounds each persona in a real job / life context:
- ICU nurse on 12-hour night shifts
- Stay-at-home mom running on 3-hour sleep
- College student in a goshiwon eating convenience store kimbap
- Call center agent hiding scroll from supervisor screen-time monitoring
- Long-haul trucker at a rest stop
- Construction worker on Friday evening

Each bio calls out WHEN they scroll and WHAT makes them stop vs swipe away.

## Forward-compat: `weight` field
Added `weight: 1.0` default on every persona. Future audience-composition feature will set different weights to reflect target demographic mix (e.g., if product targets college students, those personas get weight=2.0 so their votes count double in S5 Borda). This PR is behaviorally a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)