### PR TITLE
fix: remove unused imports in experiment files (ruff)

### DIFF
--- a/backend/tests/experiments/test_exactly_once.py
+++ b/backend/tests/experiments/test_exactly_once.py
@@ -42,9 +42,7 @@ Run:
 from __future__ import annotations
 
 import asyncio
-import json
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio

--- a/backend/tests/experiments/test_fanout_parallelism.py
+++ b/backend/tests/experiments/test_fanout_parallelism.py
@@ -34,7 +34,6 @@ Run:
 from __future__ import annotations
 
 import asyncio
-import math
 import time
 from dataclasses import dataclass
 


### PR DESCRIPTION
Hotfix for main CI failure.

PR #173 was merged before the ruff lint fix was applied. Removes unused imports:
- `test_exactly_once.py`: `import json`, `from unittest.mock import AsyncMock`
- `test_fanout_parallelism.py`: `import math`

🤖 Generated with [Claude Code](https://claude.com/claude-code)