### PR TITLE
docs: drop PR-count split from PM report

### DIFF
--- a/docs/homework/project-management-report.md
+++ b/docs/homework/project-management-report.md
@@ -32,7 +32,7 @@ We started from a V1 hackathon prototype (`gemini-social-asset`) and rewrote it 
 | Apr 15–18 | S1 grid viz, S4 vote matrix, observability | Deploy hardening, Terraform state import, destroy workflow | First E2E with full viz + resilience |
 | Apr 18–20 | Business-case doc, deck iterations, Campaign → Script rename across deck/frontend/backend, lessons-series refresh | M5-distributed-patterns experiments (fan-out, stragglers, idempotency), experiment overview, PDF export, M5-4 rerun | Final submission package |
 
-**PR split:** Sam 77 (61%), Jess 50 (39%). Every PR reviewed by the other.
+**Review discipline:** all 127 merged PRs passed through code review by the other team member before merging — enforced by branch protection on `main` (see below).
 
 ## Problems Encountered & How We Broke Them Down
 


### PR DESCRIPTION
## Summary
Follow-up to PR #183. The PM report still has a line — *'PR split: Sam 77 (61%), Jess 50 (39%). Every PR reviewed by the other.'* — that conflates a typo fix with an architectural refactor and undercuts the 'every PR reviewed' point that's actually load-bearing for a team PM report.

## Change
One-line replacement on the PM report:

> **Before:** PR split: Sam 77 (61%), Jess 50 (39%). Every PR reviewed by the other.
> **After:** Review discipline: all 127 merged PRs passed through code review by the other team member before merging — enforced by branch protection on `main` (see below).

Keeps the total (127, verifiable) and drops the individual split.

## Test plan
- [ ] Line 35 of `docs/homework/project-management-report.md` reads the new 'Review discipline' framing
- [ ] No other references to the 77/50 split remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)